### PR TITLE
Make the HTTP bind interface configurable

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.8")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.12")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0") // for Silicon

--- a/src/main/scala/viper/server/ViperConfig.scala
+++ b/src/main/scala/viper/server/ViperConfig.scala
@@ -77,6 +77,14 @@ class ViperConfig(args: Seq[String]) extends ScallopConf(args) {
 
   dependsOnAll(ideModeAdvanced, ideMode :: Nil)
 
+  var bindInterface: ScallopOption[String] = opt[String]("bind-interface",
+    descr = ("Specifies the interface that ViperServer will listen on."
+      + "The default is \"localhost\" where only connections from the local machine are accepted."
+      + "Use 0.0.0.0 to accept connections from any machine (not a good idea without HTTPS or a firewall)."),
+    default = Some("localhost"),
+    noshort=true
+  )
+
   val port: ScallopOption[Int] = opt[Int]("port", 'p',
     descr = ("Specifies the port on which ViperServer will be started."
       + s"The port must be an integer in range [${viper.server.utility.Sockets.MIN_PORT_NUMBER}-${viper.server.utility.Sockets.MAX_PORT_NUMBER}]"

--- a/src/main/scala/viper/server/ViperIDEProtocol.scala
+++ b/src/main/scala/viper/server/ViperIDEProtocol.scala
@@ -12,6 +12,7 @@ import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import spray.json.DefaultJsonProtocol
 import viper.silver.reporter.{InvalidArgumentsReport, _}
+import viper.silver.utility.{DurationEvent, TimingLogEntry}
 import viper.silver.verifier._
 
 
@@ -119,16 +120,25 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
       "result" -> obj.result.toJson)
   })
 
-  implicit val overallSuccessMessage_writer: RootJsonFormat[OverallSuccessMessage] = lift(new RootJsonWriter[OverallSuccessMessage] {
-    override def write(obj: OverallSuccessMessage): JsObject = {
-      JsObject(
-        "time" -> obj.verificationTime.toJson)
+  implicit val durationEvent_writer: RootJsonFormat[DurationEvent] = jsonFormat6(DurationEvent)
+
+  implicit val timingLogEntry_writer: RootJsonFormat[TimingLogEntry] = lift(new RootJsonWriter[TimingLogEntry] {
+    override def write(obj: TimingLogEntry): JsValue = obj match {
+      case e: DurationEvent => e.toJson
     }
+  })
+
+  implicit val overallSuccessMessage_writer: RootJsonFormat[OverallSuccessMessage] = lift(new RootJsonWriter[OverallSuccessMessage] {
+    override def write(obj: OverallSuccessMessage): JsObject = JsObject(
+      "time" -> obj.verificationTime.toJson,
+      "timingLog" -> obj.timingEvents.toJson
+    )
   })
 
   implicit val overallFailureMessage_writer: RootJsonFormat[OverallFailureMessage] = lift(new RootJsonWriter[OverallFailureMessage] {
     override def write(obj: OverallFailureMessage): JsValue = JsObject(
       "time" -> obj.verificationTime.toJson,
+      "timingLog" -> obj.timingEvents.toJson,
       "result" -> obj.result.toJson
     )
   })

--- a/src/main/scala/viper/server/ViperIDEProtocol.scala
+++ b/src/main/scala/viper/server/ViperIDEProtocol.scala
@@ -120,7 +120,18 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
       "result" -> obj.result.toJson)
   })
 
-  implicit val durationEvent_writer: RootJsonFormat[DurationEvent] = jsonFormat6(DurationEvent)
+  implicit val durationEvent_writer: RootJsonFormat[DurationEvent] = lift(new RootJsonWriter[DurationEvent] {
+    override def write(obj: DurationEvent): JsValue = obj match {
+      case DurationEvent(name, cat, ph, ts, pid, tid) => JsObject(
+        "name" -> JsString(name),
+        "cat" -> JsString(cat),
+        "ph" -> JsString(ph),
+        "ts" -> JsNumber(ts),
+        "pid" -> JsNumber(pid),
+        "tid" -> JsNumber(tid)
+      )
+    }
+  })
 
   implicit val timingLogEntry_writer: RootJsonFormat[TimingLogEntry] = lift(new RootJsonWriter[TimingLogEntry] {
     override def write(obj: TimingLogEntry): JsValue = obj match {

--- a/src/main/scala/viper/server/ViperServer.scala
+++ b/src/main/scala/viper/server/ViperServer.scala
@@ -275,7 +275,7 @@ object ViperServerRunner {
             val new_job_handle: Future[JobHandle] = (main_actor ? ViperServerProtocol.Verify(arg_list)).mapTo[JobHandle]
             new_job_handle
           })
-          complete( VerificationRequestAccept(id) )
+          complete(VerificationRequestAccept(id))
 
         } else {
           complete( VerificationRequestReject(s"the maximum number of active verification jobs are currently running ($MAX_ACTIVE_JOBS).") )

--- a/src/main/scala/viper/server/ViperServer.scala
+++ b/src/main/scala/viper/server/ViperServer.scala
@@ -409,12 +409,13 @@ object ViperServerRunner {
 
     ViperCache.initialize(logger.get, config.backendSpecificCache())
 
+    val host = config.bindInterface()
     val port = config.port()
-    val bindingFuture: Future[Http.ServerBinding] = Http().bindAndHandle(routes(logger), "localhost", port)
+    val bindingFuture: Future[Http.ServerBinding] = Http().bindAndHandle(routes(logger), host, port)
     _term_actor = system.actorOf(Terminator.props(bindingFuture), "terminator")
 
     println(s"Writing [level:${config.logLevel()}] logs into ${if (!config.logFile.isSupplied) "(default) " else ""}journal: ${logger.file.get}")
-    println(s"ViperServer online at http://localhost:$port")
+    println(s"ViperServer online at http://$host:$port")
 
   } // method main
 


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by bitbucket user **tehwalris** on 2019-03-14 14:01
> Last updated on 2020-02-03 15:46
> Original Bitbucket pull request id: 9
>
> Source: https://github.com/viperproject/viperserver/commit/2be3c1a9396115387c8fc853f8fc4720fb22847a on branch `tehwalris/viperserver/default`
> Destination: https://github.com/viperproject/viperserver/commit/7cc7ce5224a723ab1fcdbe2e7ea0cbfbd727fcab on branch `master`
>
> State: **`OPEN`**

When using ViperServer in Docker I need to connect to it from another container. For this to work, ViperServer must allow connecting from non-localhost IPs. This patch allows that as a command line option. The default behavior is unchanged.
