### PR TITLE
mapVerificationResult is now applied automatically in Silver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-syntax: glob
 target
 tmp
 .idea

--- a/src/main/scala/viper/server/VerificationWorker.scala
+++ b/src/main/scala/viper/server/VerificationWorker.scala
@@ -281,25 +281,44 @@ class ViperBackend(private val _frontend: SilFrontend) {
     }
   }
 
-  private def getMethodSpecificErrors(m: Method, errors: Seq[AbstractError]): List[AbstractVerificationError] = {
-    //The position of the error is used to determine to which Method it belongs.
-    val methodStart = m.pos.asInstanceOf[SourcePosition].start.line
-    val methodEnd = m.pos.asInstanceOf[SourcePosition].end.get.line
+  /*
+  Tries to determine which of the given errors are caused by the given method.
+  If an error's scope field is set, this information is used.
+  Otherwise, if both the given method and the error have line/column position information, we calculate if the error's
+  position is inside the method.
+  If at least one error has no scope set and no position, or the method's position is not set, we cannot determine
+  if the error belongs to the method and return None.
+   */
+  private def getMethodSpecificErrors(m: Method, errors: Seq[AbstractError]): Option[List[AbstractVerificationError]] = {
+    val methodPos = m.pos match {
+      case sp: SourcePosition => Some(sp.start.line, sp.end.get.line)
+      case _ => {
+        None
+      }
+    }
     val result = scala.collection.mutable.ListBuffer[AbstractVerificationError]()
 
     errors.foreach {
+      case e: AbstractVerificationError if e.scope.isDefined =>
+        if (e.scope.get == m)
+          result += e
       case e: AbstractVerificationError =>
         e.pos match {
           case pos: HasLineColumn =>
             val errorPos = pos.line
-            if (errorPos >= methodStart && errorPos <= methodEnd) result += e
+            if (methodPos.isEmpty)
+            {
+              return None
+            }
+            //The position of the error is used to determine to which Method it belongs.
+            if (errorPos >= methodPos.get._1 && errorPos <= methodPos.get._2) result += e
           case _ =>
-            throw new Exception("Error determining method specific errors for the cache: The reported errors should have a location")
+            return None
         }
       case e =>
         throw new Exception("Error with unexpected type found: " + e)
     }
-    result.toList
+    Some(result.toList)
   }
 
   def doCachedVerification(): Unit = {
@@ -330,12 +349,17 @@ class ViperBackend(private val _frontend: SilFrontend) {
       methodsToVerify.foreach(m => {
         _frontend.getVerificationResult.get match {
           case Failure(errors) =>
-            val errorsToCache = getMethodSpecificErrors(m, errors)
-            ViperCache.update(backendName, file, prog, m, errorsToCache) match {
-              case e :: es =>
-                _frontend.logger.debug(s"Storing new entry in cache for method (${m.name}): $e. Other entries for this method: ($es)")
-              case Nil =>
-                _frontend.logger.warn(s"Storing new entry in cache for method (${m.name}) FAILED. List of errors for this method: $errorsToCache")
+            val errorsToCacheMaybe = getMethodSpecificErrors(m, errors)
+            errorsToCacheMaybe match {
+              case Some(errorsToCache) => {
+                ViperCache.update(backendName, file, prog, m, errorsToCache) match {
+                  case e :: es =>
+                    _frontend.logger.debug(s"Storing new entry in cache for method (${m.name}): $e. Other entries for this method: ($es)")
+                  case Nil =>
+                    _frontend.logger.warn(s"Storing new entry in cache for method (${m.name}) FAILED. List of errors for this method: $errorsToCache")
+                }
+              }
+              case None =>
             }
           case Success =>
             ViperCache.update(backendName, file, prog, m, Nil) match {

--- a/src/main/scala/viper/server/VerificationWorker.scala
+++ b/src/main/scala/viper/server/VerificationWorker.scala
@@ -193,7 +193,7 @@ class ViperBackend(private val _frontend: SilFrontend) {
               case _ => Seq()
             })
           } ++ t.axioms.flatMap { ax =>
-            Definition(ax.name, "Axiom", ax.pos, Some(p)) +: (ax.pos match {
+            Definition(if (ax.isInstanceOf[NamedDomainAxiom]) ax.asInstanceOf[NamedDomainAxiom].name else "", "Axiom", ax.pos, Some(p)) +: (ax.pos match {
               case ax_p: AbstractSourcePosition =>
                 ax.exp.deepCollect {
                   case scope:Scope with Positioned =>
@@ -476,7 +476,8 @@ class ViperBackend(private val _frontend: SilFrontend) {
       case t: Domain => t.copy()(pos, t.info, t.errT)
 
       //DomainMembers
-      case t: DomainAxiom => t.copy()(pos, t.info, t.domainName, t.errT)
+      case t: NamedDomainAxiom => t.copy()(pos, t.info, t.domainName, t.errT)
+      case t: AnonymousDomainAxiom => t.copy()(pos, t.info, t.domainName, t.errT)
       case t: DomainFunc => t.copy()(pos, t.info, t.domainName, t.errT)
 
       //Statements


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by **@aterga** on 2019-05-26 13:21
> Last updated on 2020-02-03 15:46
> Original Bitbucket pull request id: 10
>
> Participants:
>
> * **@mschwerhoff** (reviewer)
>
> Source: https://github.com/viperproject/viperserver/commit/bd4559f52f7a1a46707003fcbaabecc662a90a46 on branch `arshavir/viperserver-plugin-aware-reporting/default`
> Destination: https://github.com/viperproject/viperserver/commit/7cc7ce5224a723ab1fcdbe2e7ea0cbfbd727fcab on branch `master`
>
> State: **`OPEN`**

For details, see [Silver PL 120](https://github.com/viperproject/silver/pull/421).
