### PR TITLE
Unit Tests with Concurrent Verifications

### DIFF
--- a/src/main/scala/viper/server/core/ViperCache.scala
+++ b/src/main/scala/viper/server/core/ViperCache.scala
@@ -30,6 +30,7 @@ object ViperCache extends Cache {
   def initialize(logger: Logger, backendSpecificCache: Boolean): Unit = {
     _backendSpecificCache = backendSpecificCache
     _logger = logger
+    resetCache()
   }
 
   def applyCache(


### PR DESCRIPTION
Reenables unit tests for concurrent verification jobs and fixes ViperServer to clear the cache whenever it starts.

This PR requires the changes from [Silver PR #503](https://github.com/viperproject/silver/pull/503) and [Silicon PR #533](https://github.com/viperproject/silicon/pull/533)