### PR TITLE
Fixes Termination of HTTP Server

### DIFF
--- a/src/main/scala/viper/server/vsi/Terminator.scala
+++ b/src/main/scala/viper/server/vsi/Terminator.scala
@@ -31,9 +31,6 @@ class Terminator[R](ast_jobs: JobPool[AstJobId, AstHandle[R]],
                     bindingFuture: Option[Future[Http.ServerBinding]])
                 (implicit val ctx: VerificationExecutionContext) extends Actor {
 
-  // note that the execution context is NOT terminated such that clients
-  // have better control over when the execution context should be terminated
-
   override def receive: PartialFunction[Any, Unit] = {
     case Terminator.Exit =>
       bindingFuture match {
@@ -42,5 +39,7 @@ class Terminator[R](ast_jobs: JobPool[AstJobId, AstHandle[R]],
             .flatMap(_.unbind()) // trigger unbinding from the port
         case None =>
       }
+      // note that the execution context is NOT terminated such that clients
+      // have better control over when the execution context should be terminated
   }
 }

--- a/src/main/scala/viper/server/vsi/Terminator.scala
+++ b/src/main/scala/viper/server/vsi/Terminator.scala
@@ -6,11 +6,11 @@
 
 package viper.server.vsi
 
-import akka.actor.{Actor, ActorSystem, Props}
+import akka.actor.{Actor, Props}
 import akka.http.scaladsl.Http
 import viper.server.core.VerificationExecutionContext
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 // --- Actor: Terminator ---
 

--- a/src/test/scala/viper/server/core/ViperServerHttpSpec.scala
+++ b/src/test/scala/viper/server/core/ViperServerHttpSpec.scala
@@ -38,7 +38,7 @@ class ViperServerHttpSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     server
   }
 
-  private val _routsUnderTest = viperServerHttp.routes()
+  private val _routesUnderTest = viperServerHttp.routes()
 
   def printRequestResponsePair(req: String, res: String): Unit = {
     println(s">>> ViperServer test request `$req` response in the following response: $res")
@@ -72,7 +72,7 @@ class ViperServerHttpSpec extends AnyWordSpec with Matchers with ScalatestRouteT
 
   "ViperServer" should {
     s"start a verification process using `$tool` over a small Viper program" in {
-      Post("/verify", VerificationRequest(testSimpleViperCode_cmd)) ~> _routsUnderTest ~> check {
+      Post("/verify", VerificationRequest(testSimpleViperCode_cmd)) ~> _routesUnderTest ~> check {
         //printRequestResponsePair(s"POST, /verify, $testSimpleViperCode_cmd", responseAs[String])
         status should ===(StatusCodes.OK)
         contentType should ===(ContentTypes.`application/json`)
@@ -81,7 +81,7 @@ class ViperServerHttpSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     "respond with the result for process #0" in {
-      Get("/verify/0") ~> _routsUnderTest ~> check {
+      Get("/verify/0") ~> _routesUnderTest ~> check {
         //printRequestResponsePair(s"GET, /verify/0", responseAs[String])
         status should ===(StatusCodes.OK)
         contentType should ===(ContentTypes.`application/json`)
@@ -90,7 +90,7 @@ class ViperServerHttpSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     s"start another verification process using `$tool` on an empty file" in {
-      Post("/verify", VerificationRequest(testEmptyFile_cmd)) ~> _routsUnderTest ~> check {
+      Post("/verify", VerificationRequest(testEmptyFile_cmd)) ~> _routesUnderTest ~> check {
         //printRequestResponsePair(s"POST, /verify, $testEmptyFile_cmd", responseAs[String])
         status should ===(StatusCodes.OK)
         contentType should ===(ContentTypes.`application/json`)
@@ -99,7 +99,7 @@ class ViperServerHttpSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     "respond with the result for process #1" in {
-      Get("/verify/1") ~> _routsUnderTest ~> check {
+      Get("/verify/1") ~> _routesUnderTest ~> check {
         //printRequestResponsePair(s"GET, /verify/1", responseAs[String])
         status should ===(StatusCodes.OK)
         contentType should ===(ContentTypes.`application/json`)
@@ -108,7 +108,7 @@ class ViperServerHttpSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     s"start another verification process using `$tool` on an non-existent file" in {
-      Post("/verify", VerificationRequest(testNonExistingFile_cmd)) ~> _routsUnderTest ~> check {
+      Post("/verify", VerificationRequest(testNonExistingFile_cmd)) ~> _routesUnderTest ~> check {
         //printRequestResponsePair(s"POST, /verify, $testEmptyFile_cmd", responseAs[String])
         status should ===(StatusCodes.OK)
         contentType should ===(ContentTypes.`application/json`)
@@ -117,7 +117,7 @@ class ViperServerHttpSpec extends AnyWordSpec with Matchers with ScalatestRouteT
     }
 
     "stop all running executions and terminate self" in {
-      Get("/exit") ~> _routsUnderTest ~> check {
+      Get("/exit") ~> _routesUnderTest ~> check {
         //printRequestResponsePair(s"GET, /exit", responseAs[String])
         status should ===(StatusCodes.OK)
         contentType should ===(ContentTypes.`application/json`)


### PR DESCRIPTION
The HTTP server now offers a way to await its shutdown. The Terminator actor no longer uses some actor system and execution context but takes `VerificationExecutionContext`. However, the execution context is not terminated but is an obligation of clients to terminate when appropriate.