### PR TITLE
Remove Viper Tools Creation

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -327,7 +327,7 @@ jobs:
       - name: Trigger Viper-IDE CI
         # TODO: change ref to "master"!
         run: |
-          curl --request POST \
+          curl --fail --request POST \
           --user 'viper-admin:${{ secrets.VIPER_ADMIN_TOKEN }}' \
           --header 'Accept: application/vnd.github.v3+json' \
           --url 'https://api.github.com/repos/viperproject/viper-ide/actions/workflows/test.yml/dispatches' \

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -262,7 +262,7 @@ jobs:
   create-nightly-release:
     # this job creates a new nightly pre-release, set viperserver.jar as artifacts, and deletes old releases
     if: (github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'nightly') || github.event_name == 'schedule'
-    needs: create-viper-tools
+    needs: test
     runs-on: ubuntu-latest
     env:
       # specifies that `latest` artifacts from `build` job should be used for nightly releases:
@@ -345,7 +345,7 @@ jobs:
   create-stable-release:
     # this job creates a stable draft-release and set viperserver.jar as artifacts
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'stable'
-    needs: create-viper-tools
+    needs: test
     runs-on: ubuntu-latest
     env:
       # specifies that `release` artifacts from `build` job should be used for stable releases:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -259,90 +259,6 @@ jobs:
           path: viperserver/logs
 
 
-  create-viper-tools:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-    needs: test
-    strategy:
-      # tests should not be stopped when they fail on one of the OSes:
-      fail-fast: false
-      matrix:
-        name: [latest, release]
-        include:
-          - name: latest
-            win-tools-url: "http://viper.ethz.ch/downloads/ViperToolsNightlyWin.zip"
-            linux-tools-url: "http://viper.ethz.ch/downloads/ViperToolsNightlyLinux.zip"
-            mac-tools-url: "http://viper.ethz.ch/downloads/ViperToolsNightlyMac.zip"
-          - name: release
-            win-tools-url: "http://viper.ethz.ch/downloads/ViperToolsLastReleaseWin.zip"
-            linux-tools-url: "http://viper.ethz.ch/downloads/ViperToolsLastReleaseLinux.zip"
-            mac-tools-url: "http://viper.ethz.ch/downloads/ViperToolsLastReleaseMac.zip"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install prerequisites
-        run: sudo apt-get install zip unzip
-
-      - name: Download ViperServer fat JAR
-        uses: actions/download-artifact@v2
-        with:
-          name: viperserver-${{ matrix.name }}-fat-jar
-
-      - name: Download Viper Tools for Windows
-        run: curl --fail --silent --show-error ${{ matrix.win-tools-url }} --output ViperToolsWin.zip
-      - name: Unzip Viper Tools for Windows
-        run: unzip ViperToolsWin.zip -d OrigViperToolsWin
-      - name: Download Viper Tools for Linux
-        run: curl --fail --silent --show-error ${{ matrix.linux-tools-url }} --output ViperToolsLinux.zip
-      - name: Unzip Viper Tools for Linux
-        run: unzip ViperToolsLinux.zip -d OrigViperToolsLinux
-      - name: Download Viper Tools for macOS
-        run: curl --fail --silent --show-error ${{ matrix.mac-tools-url }} --output ViperToolsMac.zip
-      - name: Unzip Viper Tools for macOS
-        run: unzip ViperToolsMac.zip -d OrigViperToolsMac
-
-      - name: Create a fresh Viper Tools folder per platform
-        run: |
-          mkdir -p ViperToolsWin
-          mkdir -p ViperToolsLinux
-          mkdir -p ViperToolsMac
-
-      - name: Copy boogie from OrigViperTools to ViperTools
-        run: |
-          cp -R OrigViperToolsWin/boogie ViperToolsWin/boogie/
-          cp -R OrigViperToolsLinux/boogie ViperToolsLinux/boogie/
-          cp -R OrigViperToolsMac/boogie ViperToolsMac/boogie/
-
-      - name: Copy z3 from OrigViperTools to ViperTools
-        run: |
-          cp -R OrigViperToolsWin/z3 ViperToolsWin/z3/
-          cp -R OrigViperToolsLinux/z3 ViperToolsLinux/z3/
-          cp -R OrigViperToolsMac/z3 ViperToolsMac/z3/
-
-      - name: Copy ViperServer fat JAR to ViperTools
-        run: |
-          mkdir -p ViperToolsWin/server && cp viperserver.jar ViperToolsWin/server
-          mkdir -p ViperToolsLinux/server && cp viperserver.jar ViperToolsLinux/server
-          mkdir -p ViperToolsMac/server && cp viperserver.jar ViperToolsMac/server
-
-      - name: Create folder to store all ViperTools platform zip files
-        run: mkdir deploy
-        # note that we change into the tool folder to zip it. This avoids including the parent folder in the zip
-      - name: Zip ViperTools for Windows
-        run: zip -r ../deploy/ViperToolsWin.zip ./*
-        working-directory: ViperToolsWin
-      - name: Zip ViperTools for Linux
-        run: zip -r ../deploy/ViperToolsLinux.zip ./*
-        working-directory: ViperToolsLinux
-      - name: Zip ViperTools for macOS
-        run: zip -r ../deploy/ViperToolsMac.zip ./*
-        working-directory: ViperToolsMac
-
-      - name: Upload ViperTools zip files
-        uses: actions/upload-artifact@v2
-        with:
-          name: ViperTools-${{ matrix.name }}
-          path: deploy
-
-
   create-nightly-release:
     # this job creates a new nightly pre-release, set viperserver.jar as artifacts, and deletes old releases
     if: (github.event_name == 'workflow_dispatch' && github.event.inputs.type == 'nightly') || github.event_name == 'schedule'
@@ -352,6 +268,9 @@ jobs:
       # specifies that `latest` artifacts from `build` job should be used for nightly releases:
       NAME: latest # has to match matrix.name in `build` job
     steps:
+      - name: Install prerequisites
+        run: sudo apt-get install curl
+
       - name: Download ViperServer skinny JARs
         uses: actions/download-artifact@v2
         with:
@@ -362,12 +281,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: viperserver-${{ env.NAME }}-fat-jar
-          path: deploy
-
-      - name: Download ViperTools
-        uses: actions/download-artifact@v2
-        with:
-          name: ViperTools-${{ env.NAME }}
           path: deploy
 
       - name: Download version file
@@ -411,35 +324,9 @@ jobs:
           asset_name: viperserver.jar
           asset_content_type: application/octet-stream
 
-      - name: Upload ViperTools for Windows
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/ViperToolsWin.zip
-          asset_name: ViperToolsWin.zip
-          asset_content_type: application/zip
-
-      - name: Upload ViperTools for Ubuntu
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/ViperToolsLinux.zip
-          asset_name: ViperToolsLinux.zip
-          asset_content_type: application/zip
-
-      - name: Upload ViperTools for macOS
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/ViperToolsMac.zip
-          asset_name: ViperToolsMac.zip
-          asset_content_type: application/zip
+      - name: Trigger Viper-IDE CI
+        # TODO: change ref to "master"!
+        run: curl -u viper-admin:${{ secrets.VIPER_ADMIN_TOKEN }} -X POST -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/viperproject/viper-ide/actions/workflows/test.yml/dispatches -d '{"ref":"viper-tools-release", "inputs":{"type":"nightly","viperserver_tag_name":"${{ env.TAG_NAME }}","tag_name":"${{ env.TAG_NAME }}","release_name":"Nightly Release ${{ env.TAG_NAME }}"}}'
 
 
   create-stable-release:
@@ -461,12 +348,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: viperserver-${{ env.NAME }}-fat-jar
-          path: deploy
-
-      - name: Download ViperTools
-        uses: actions/download-artifact@v2
-        with:
-          name: ViperTools-${{ env.NAME }}
           path: deploy
 
       - name: Download version file
@@ -506,33 +387,3 @@ jobs:
           asset_path: deploy/viperserver.jar
           asset_name: viperserver.jar
           asset_content_type: application/octet-stream
-
-      - name: Upload ViperTools for Windows
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/ViperToolsWin.zip
-          asset_name: ViperToolsWin.zip
-          asset_content_type: application/zip
-
-      - name: Upload ViperTools for Ubuntu
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/ViperToolsLinux.zip
-          asset_name: ViperToolsLinux.zip
-          asset_content_type: application/zip
-
-      - name: Upload ViperTools for macOS
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: deploy/ViperToolsMac.zip
-          asset_name: ViperToolsMac.zip
-          asset_content_type: application/zip

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -325,14 +325,13 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Trigger Viper-IDE CI
-        # TODO: change ref to "master"!
         run: |
           curl --fail --request POST \
           --user 'viper-admin:${{ secrets.VIPER_ADMIN_TOKEN }}' \
           --header 'Accept: application/vnd.github.v3+json' \
           --url 'https://api.github.com/repos/viperproject/viper-ide/actions/workflows/test.yml/dispatches' \
           --data "{ \
-            \"ref\":\"viper-tools-release\", \
+            \"ref\":\"master\", \
             \"inputs\":{ \
               \"type\":\"nightly\", \
               \"viperserver_tag_name\":\"${{ env.TAG_NAME }}\", \

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -326,7 +326,20 @@ jobs:
 
       - name: Trigger Viper-IDE CI
         # TODO: change ref to "master"!
-        run: curl -u viper-admin:${{ secrets.VIPER_ADMIN_TOKEN }} -X POST -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/viperproject/viper-ide/actions/workflows/test.yml/dispatches -d '{"ref":"viper-tools-release", "inputs":{"type":"nightly","viperserver_tag_name":"${{ env.TAG_NAME }}","tag_name":"${{ env.TAG_NAME }}","release_name":"Nightly Release ${{ env.TAG_NAME }}"}}'
+        run: |
+          curl --request POST \
+          --user 'viper-admin:${{ secrets.VIPER_ADMIN_TOKEN }}' \
+          --header 'Accept: application/vnd.github.v3+json' \
+          --url 'https://api.github.com/repos/viperproject/viper-ide/actions/workflows/test.yml/dispatches' \
+          --data '{ \
+            "ref":"viper-tools-release", \
+            "inputs":{ \
+              "type":"nightly", \
+              "viperserver_tag_name":"${{ env.TAG_NAME }}", \
+              "tag_name":"${{ env.TAG_NAME }}", \
+              "release_name":"Nightly Release ${{ env.TAG_NAME }}" \
+            } \
+          }'
 
 
   create-stable-release:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -331,15 +331,15 @@ jobs:
           --user 'viper-admin:${{ secrets.VIPER_ADMIN_TOKEN }}' \
           --header 'Accept: application/vnd.github.v3+json' \
           --url 'https://api.github.com/repos/viperproject/viper-ide/actions/workflows/test.yml/dispatches' \
-          --data '{ \
-            "ref":"viper-tools-release", \
-            "inputs":{ \
-              "type":"nightly", \
-              "viperserver_tag_name":"${{ env.TAG_NAME }}", \
-              "tag_name":"${{ env.TAG_NAME }}", \
-              "release_name":"Nightly Release ${{ env.TAG_NAME }}" \
+          --data "{ \
+            \"ref\":\"viper-tools-release\", \
+            \"inputs\":{ \
+              \"type\":\"nightly\", \
+              \"viperserver_tag_name\":\"${{ env.TAG_NAME }}\", \
+              \"tag_name\":\"${{ env.TAG_NAME }}\", \
+              \"release_name\":\"Nightly Release ${{ env.TAG_NAME }}\" \
             } \
-          }'
+          }"
 
 
   create-stable-release:

--- a/src/main/scala/viper/server/ViperServerRunner.scala
+++ b/src/main/scala/viper/server/ViperServerRunner.scala
@@ -45,6 +45,9 @@ object ViperServerRunner {
     println("HTTP server has been stopped")
     executor.terminate()
     println("executor service has been shut down")
+    // the following `exit` call is required such that the server eventually terminates for `longDuration.vpr` in the
+    // test suite of viper-ide
+    System.exit(0)
   }
 
   /**
@@ -73,8 +76,12 @@ object ViperServerRunner {
       println("listener thread from server has stopped")
       executor.terminate()
       println("executor service has been shut down")
+      System.exit(0)
     } catch {
-      case e: IOException => println(s"IOException occurred: ${e.toString}")
+      case e: IOException => {
+        println(s"IOException occurred: ${e.toString}")
+        System.exit(1)
+      }
     }
   }
 


### PR DESCRIPTION
Viper Tools should no longer be built as part of CI of this repo. Instead, the [Viper-IDE](https://github.com/viperproject/viper-ide) repository builds them, checks for compatibility, and only then releases them.
Additionally, this PR adds a call to `System.exit` which is required to terminate the server after verifying certain Viper files