### PR TITLE
Create Nightly Release Only on Change

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -288,17 +288,6 @@ jobs:
         with:
           name: versions-${{ env.NAME }}.txt
 
-      - name: Debug
-        run: |
-          curl --fail --silent \
-            --header 'Accept: application/vnd.github.v3+json' \
-            --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
-            --url 'https://api.github.com/repos/viperproject/viperserver/releases' \
-          | \
-          jq --rawfile VERSIONS versions.txt \
-            'map(select(.prerelease == true) | .body)'
-          cat versions.txt
-
       - name: Check whether commits have changed
           # the following command queries all releases (as JSON) and passes it to `jq` that performs the following
           # filtering:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -288,6 +288,17 @@ jobs:
         with:
           name: versions-${{ env.NAME }}.txt
 
+      - name: Debug
+        run: |
+          curl --fail --silent \
+            --header 'Accept: application/vnd.github.v3+json' \
+            --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            --url 'https://api.github.com/repos/viperproject/viperserver/releases' \
+          | \
+          jq --rawfile VERSIONS versions.txt \
+            'map(select(.prerelease == true) | .body)'
+          cat versions.txt
+
       - name: Check whether commits have changed
           # the following command queries all releases (as JSON) and passes it to `jq` that performs the following
           # filtering:

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -289,6 +289,13 @@ jobs:
           name: versions-${{ env.NAME }}.txt
 
       - name: Check whether commits have changed
+          # the following command queries all releases (as JSON) and passes it to `jq` that performs the following
+          # filtering:
+          # 1. only consider prereleases (instead of stable releases)
+          # 2. extract body
+          # 3. check if $VERSIONS is contained in the release's body. $VERSIONS stores the file content of versions.txt
+          # 4. return 'true" if at least one release satisfies the criterion
+          # MATCHING_RELEASE is 'true' if a matching release has been found and thus no new release should be created
         run: |
           MATCHING_RELEASE=$( \
             curl --fail --silent \
@@ -296,15 +303,9 @@ jobs:
               --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
               --url 'https://api.github.com/repos/viperproject/vs-verification-toolbox-release-testing/releases' \
             | \
-            jq --rawfile VERSIONS versions.txt \ # read versions.txt and store content in $VERSIONS
+            jq --rawfile VERSIONS versions.txt \
               'map(select(.prerelease == true) | .body | contains($VERSIONS)) | any')
-              # the filter above does the following:
-              # 1. only consider prereleases (instead of stable releases)
-              # 2. extract body
-              # 3. check if $VERSIONS is contained in the release's body
-              # 4. return 'true" if at least one release satisfies the criterion
           echo "MATCHING_RELEASE=$MATCHING_RELEASE" >> $GITHUB_ENV
-          # MATCHING_RELEASE is 'true' if a matching release has been found and thus no new release should be created
 
       - name: Create release tag
         if: env.MATCHING_RELEASE != 'true'

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -301,7 +301,7 @@ jobs:
             curl --fail --silent \
               --header 'Accept: application/vnd.github.v3+json' \
               --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
-              --url 'https://api.github.com/repos/viperproject/vs-verification-toolbox-release-testing/releases' \
+              --url 'https://api.github.com/repos/viperproject/viperserver/releases' \
             | \
             jq --rawfile VERSIONS versions.txt \
               'map(select(.prerelease == true) | .body | contains($VERSIONS)) | any')

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -288,11 +288,31 @@ jobs:
         with:
           name: versions-${{ env.NAME }}.txt
 
+      - name: Check whether commits have changed
+        run: |
+          MATCHING_RELEASE=$( \
+            curl --fail --silent \
+              --header 'Accept: application/vnd.github.v3+json' \
+              --header 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+              --url 'https://api.github.com/repos/viperproject/vs-verification-toolbox-release-testing/releases' \
+            | \
+            jq --rawfile VERSIONS versions.txt \ # read versions.txt and store content in $VERSIONS
+              'map(select(.prerelease == true) | .body | contains($VERSIONS)) | any')
+              # the filter above does the following:
+              # 1. only consider prereleases (instead of stable releases)
+              # 2. extract body
+              # 3. check if $VERSIONS is contained in the release's body
+              # 4. return 'true" if at least one release satisfies the criterion
+          echo "MATCHING_RELEASE=$MATCHING_RELEASE" >> $GITHUB_ENV
+          # MATCHING_RELEASE is 'true' if a matching release has been found and thus no new release should be created
+
       - name: Create release tag
+        if: env.MATCHING_RELEASE != 'true'
         shell: bash
         run: echo "TAG_NAME=$(date +v-%Y-%m-%d-%H%M)" >> $GITHUB_ENV
 
       - name: Create nightly release
+        if: env.MATCHING_RELEASE != 'true'
         id: create_release
         uses: viperproject/create-nightly-release@v1
         env:
@@ -305,6 +325,7 @@ jobs:
           keep_num: 1 # keep the previous nightly release such that there are always two
 
       - name: Upload ViperServer skinny jars
+        if: env.MATCHING_RELEASE != 'true'
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -315,6 +336,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload ViperServer fat jar artifact
+        if: env.MATCHING_RELEASE != 'true'
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -325,6 +347,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Trigger Viper-IDE CI
+        if: env.MATCHING_RELEASE != 'true'
         run: |
           curl --fail --request POST \
           --user 'viper-admin:${{ secrets.VIPER_ADMIN_TOKEN }}' \


### PR DESCRIPTION
@fpoli will periodically create PRs when the Viper Tools change. To reduce the number of unnecessary PRs that are created even though the tools contained in the ZIP files have not changed, this PR compares the commit hashes of ViperServer, Silver, Silicon, and Carbon with those used for (already existing) nightly releases. A new nightly release will only be triggered in the `viper-ide` repository if at least one commit hash has changed.
The check, as implemented in this PR, works because `versions.txt` stores the current commit hashes and is used as body of the nightly release. Thus, one can easily check the content of the current `versions.txt` file against the bodies of the releases.