### PR TITLE
Support typed definitions in ProgramDefinitionsProvider

### DIFF
--- a/src/main/scala/viper/server/frontends/http/jsonWriters/ViperIDEProtocol.scala
+++ b/src/main/scala/viper/server/frontends/http/jsonWriters/ViperIDEProtocol.scala
@@ -15,6 +15,7 @@ import spray.json.DefaultJsonProtocol
 import viper.server.vsi.{AstJobId, VerJobId}
 import viper.silicon.SymbLog
 import viper.silicon.state.terms.Term
+import viper.silver.ast.{Position => _, _}
 import viper.silver.reporter._
 import viper.silver.verifier.{ValueEntry, _}
 
@@ -295,14 +296,67 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
     override def write(obj: ProgramOutlineReport) = JsObject("members" -> JsArray(obj.members.map(_.toJson).toVector))
   })
 
+  implicit val viperAtomicType_writer: RootJsonFormat[viper.silver.ast.AtomicType] = lift(new RootJsonWriter[AtomicType] {
+    override def write(obj: AtomicType) = obj match {
+      case viper.silver.ast.Int => JsString("Int")
+      case viper.silver.ast.Bool => JsString("Bool")
+      case viper.silver.ast.Perm => JsString("Perm")
+      case viper.silver.ast.Ref => JsString("Ref")
+      case viper.silver.ast.InternalType => JsString("Internal")
+      case viper.silver.ast.Wand => JsString("Wand")
+      case viper.silver.ast.BackendType(boogieName, smtName) =>
+        JsObject("boogieName" -> JsString(boogieName), "smtName" -> JsString(smtName))
+    }
+  })
+
+  implicit val viperGenericType_writer: RootJsonFormat[viper.silver.ast.GenericType] = lift(new RootJsonWriter[GenericType] {
+    override def write(obj: GenericType) = if (obj.isConcrete) {
+      // If this is a concrete type instantiation, we serialize it concretely
+      obj match {
+        case col: CollectionType =>
+          JsObject("collection" -> JsString(col.genericName), "elements" -> col.elementType.toJson)
+        case MapType(keyType, valueType) =>
+          JsObject("collection" -> JsString("Map"), "keys" -> keyType.toJson, "values" -> valueType.toJson)
+        case DomainType(domainName, partialTypVarsMap) =>
+          JsObject("collection" -> JsString(domainName), "typeParams" -> JsArray(partialTypVarsMap.values.map(_.toJson).toVector))
+      }
+    } else {
+      // If this is not a concrete type instantiation, we serialize it generically
+      JsString(obj.genericName)
+    }
+  })
+
+  implicit val viperType_writer: RootJsonFormat[viper.silver.ast.Type] = lift(new RootJsonWriter[Type] {
+    override def write(obj: Type) = obj match {
+      case atomic: AtomicType =>
+        JsObject("kind" -> JsString("atomic"), "typename" -> atomic.toJson)
+      case generic: GenericType =>
+        JsObject("kind" -> JsString("generic"), "typename" -> generic.toJson, "isConcrete" -> JsBoolean(generic.isConcrete))
+      case ext: ExtensionType =>
+        JsObject("kind" -> JsString("extension"), "typename" -> JsString(ext.toString()))
+      case weird_type =>
+        /** TODO: check why trait [[viper.silver.ast.Type]] is not sealed */
+        JsObject("kind" -> JsString("weird_type"), "typename" -> JsString(weird_type.toString()))
+    }
+  })
+
+  implicit val symbolType_writer: RootJsonFormat[SymbolType] = lift(new RootJsonWriter[SymbolType] {
+    override def write(obj: SymbolType) = obj match {
+      case typed_symbol: TypedSymbol =>
+        JsObject("name" -> JsString(typed_symbol.name), "viperType" -> typed_symbol.viperType.toJson)
+      case untyped_symbol =>
+        JsObject("name" -> JsString(untyped_symbol.name))
+    }
+  })
+
   /** Legacy marshaller format. Using three different position types in one case class is ugly, but a valid
     * workaround for handling all cases of AST construction. If you want to try to improve/refactor, see
-    * [[ViperBackend.collectDefinitions]] for the usage Definition.
+    * [[viper.server.utility.ProgramDefinitionsProvider]] for the usage Definition.
     */
   implicit val definition_writer: RootJsonFormat[Definition] = lift(new RootJsonWriter[Definition] {
     override def write(obj: Definition) = JsObject(
       "name" -> JsString(obj.name),
-      "type" -> JsString(obj.typ),
+      "type" -> obj.typ.toJson,
       "location" -> (obj.location match {
         case p:Position => p.toJson
         case _ => JsString("<undefined>")

--- a/src/main/scala/viper/server/frontends/http/jsonWriters/ViperIDEProtocol.scala
+++ b/src/main/scala/viper/server/frontends/http/jsonWriters/ViperIDEProtocol.scala
@@ -105,10 +105,8 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
       JsObject(
         "type" -> JsString(entity_type),
         "name" -> JsString(obj.name),
-        "position" -> (obj.pos match {
-          case src_pos: DefPosition => src_pos.toJson
-          case no_pos => JsString(no_pos.toString)
-        }))
+        "position" -> obj.pos.toJson
+      )
     }
   })
 
@@ -175,20 +173,14 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
           JsObject(
             "tag" -> JsString(obj.fullId),
             "text" -> JsString(obj.readableMessage),
-            "position" -> (obj.pos match {
-              case src_pos: DefPosition => src_pos.toJson
-              case no_pos => JsString(no_pos.toString)
-            }),
+            "position" -> obj.pos.toJson,
             "cached" -> JsBoolean(obj.cached),
             "counterexample" -> e.counterexample.get.toJson)
         case _ =>
           JsObject(
             "tag" -> JsString(obj.fullId),
             "text" -> JsString(obj.readableMessage),
-            "position" -> (obj.pos match {
-              case src_pos: DefPosition => src_pos.toJson
-              case no_pos => JsString(no_pos.toString)
-            }),
+            "position" -> obj.pos.toJson,
             "cached" -> JsBoolean(obj.cached))
       }
     }
@@ -365,10 +357,7 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
     override def write(obj: Definition) = JsObject(
       "name" -> JsString(obj.name),
       "type" -> obj.typ.toJson,
-      "location" -> (obj.location match {
-        case p:DefPosition => p.toJson
-        case _ => JsString("<undefined>")
-      }),
+      "location" -> obj.location.toJson,
       "scopeStart" -> (obj.scope match {
         case Some(s) => JsString(s"${s.start.line}:${s.start.column}")
         case _ => JsString("global")

--- a/src/main/scala/viper/server/frontends/lsp/DataProtocol.scala
+++ b/src/main/scala/viper/server/frontends/lsp/DataProtocol.scala
@@ -7,7 +7,7 @@
 package viper.server.frontends.lsp
 
 import org.eclipse.lsp4j.{Diagnostic, Position, Range}
-import viper.silver.reporter.SymbolType
+import viper.silver.reporter.SymbolKind
 
 object VerificationSuccess extends Enumeration {
   type VerificationSuccess = Value
@@ -108,7 +108,7 @@ case class PlatformDependentURL (
               linux: Option[String])
 
 // scope == null means global scope
-case class Definition(definition_type: SymbolType, name: String, code_location: Position, scope: Range)
+case class Definition(definition_type: SymbolKind, name: String, code_location: Position, scope: Range)
 
 case class BackendOutput(
               typ: String,

--- a/src/main/scala/viper/server/frontends/lsp/DataProtocol.scala
+++ b/src/main/scala/viper/server/frontends/lsp/DataProtocol.scala
@@ -7,6 +7,7 @@
 package viper.server.frontends.lsp
 
 import org.eclipse.lsp4j.{Diagnostic, Position, Range}
+import viper.silver.reporter.SymbolType
 
 object VerificationSuccess extends Enumeration {
   type VerificationSuccess = Value
@@ -107,7 +108,7 @@ case class PlatformDependentURL (
               linux: Option[String])
 
 // scope == null means global scope
-case class Definition(definition_type: String, name: String, code_location: Position, scope: Range)
+case class Definition(definition_type: SymbolType, name: String, code_location: Position, scope: Range)
 
 case class BackendOutput(
               typ: String,

--- a/src/main/scala/viper/server/utility/ProgramDefinitionsProvider.scala
+++ b/src/main/scala/viper/server/utility/ProgramDefinitionsProvider.scala
@@ -7,10 +7,10 @@
 package viper.server.utility
 
 import scala.language.postfixOps
-
-import viper.silver.ast.{AbstractSourcePosition, Domain, Field, Function, LocalVarDecl, Method, NamedDomainAxiom, Positioned, Predicate, Program, Scope}
+import viper.silver.ast.{AbstractSourcePosition, Declaration, Domain, Field, Function, LocalVarDecl, Method,
+  NamedDomainAxiom, Positioned, Predicate, Program, Scope, Typed}
 import viper.silver.frontend.SilFrontend
-import viper.silver.reporter.{Definition, ProgramDefinitionsReport, ProgramOutlineReport, StatisticsReport}
+import viper.silver.reporter._
 
 trait ProgramDefinitionsProvider {
   protected val _frontend: SilFrontend
@@ -18,24 +18,31 @@ trait ProgramDefinitionsProvider {
   def collect(program: Program): List[Definition] = {
     (program.members.collect {
       case t: Method =>
-        (Definition(t.name, "Method", t.pos) +: (t.pos match {
+        (Definition(t.name, ViperMethod, t.pos) +: (t.pos match {
           case p: AbstractSourcePosition =>
-            t.formalArgs.map { arg => Definition(arg.name, "Argument", arg.pos, Some(p)) } ++
-              t.formalReturns.map { arg => Definition(arg.name, "Return", arg.pos, Some(p)) }
+            t.formalArgs.map { arg =>
+              Definition(arg.name, ViperArgument(arg.typ), arg.pos, Some(p)) } ++
+              t.formalReturns.map { arg =>
+                Definition(arg.name, ViperReturnParameter(arg.typ), arg.pos, Some(p)) }
           case _ => Seq()
         })) ++ t.deepCollectInBody {
           case scope: Scope with Positioned =>
             scope.pos match {
               case p: AbstractSourcePosition =>
-                scope.scopedDecls.map { local_decl => Definition(local_decl.name, "Local", local_decl.pos, Some(p)) }
+                scope.scopedDecls.map {
+                  case typed_decl: Declaration with Typed =>
+                    Definition(typed_decl.name, ViperTypedLocalDefinition(typed_decl.typ), typed_decl.pos, Some(p))
+                  case untyped_decl =>
+                    Definition(untyped_decl.name, ViperUntypedLocalDefinition, untyped_decl.pos, Some(p))
+                }
               case _ => Seq()
             }
         }.flatten
 
       case t: Function =>
-        (Definition(t.name, "Function", t.pos) +: (t.pos match {
+        (Definition(t.name, ViperFunction, t.pos) +: (t.pos match {
           case p: AbstractSourcePosition =>
-            t.formalArgs.map { arg => Definition(arg.name, "Argument", arg.pos, Some(p)) }
+            t.formalArgs.map { arg => Definition(arg.name, ViperArgument(arg.typ), arg.pos, Some(p)) }
           case _ => Seq()
         })) ++ (t.body match {
           case Some(exp) =>
@@ -43,7 +50,12 @@ trait ProgramDefinitionsProvider {
               case scope:Scope with Positioned =>
                 scope.pos match {
                   case p: AbstractSourcePosition =>
-                    scope.scopedDecls.map { local_decl => Definition(local_decl.name, "Local", local_decl.pos, Some(p)) }
+                    scope.scopedDecls.map {
+                      case typed_decl: Declaration with Typed =>
+                        Definition(typed_decl.name, ViperTypedLocalDefinition(typed_decl.typ), typed_decl.pos, Some(p))
+                      case untyped_decl =>
+                        Definition(untyped_decl.name, ViperUntypedLocalDefinition, untyped_decl.pos, Some(p))
+                    }
                   case _ => Seq()
                 }
             } flatten
@@ -51,9 +63,9 @@ trait ProgramDefinitionsProvider {
         })
 
       case t: Predicate =>
-        (Definition(t.name, "Predicate", t.pos) +: (t.pos match {
+        (Definition(t.name, ViperPredicate, t.pos) +: (t.pos match {
           case p: AbstractSourcePosition =>
-            t.formalArgs.map { arg => Definition(arg.name, "Argument", arg.pos, Some(p)) }
+            t.formalArgs.map { arg => Definition(arg.name, ViperArgument(arg.typ), arg.pos, Some(p)) }
           case _ => Seq()
         })) ++ (t.body match {
           case Some(exp) =>
@@ -61,7 +73,12 @@ trait ProgramDefinitionsProvider {
               case scope:Scope with Positioned =>
                 scope.pos match {
                   case p: AbstractSourcePosition =>
-                    scope.scopedDecls.map { local_decl => Definition(local_decl.name, "Local", local_decl.pos, Some(p)) }
+                    scope.scopedDecls.map {
+                      case typed_decl: Declaration with Typed =>
+                        Definition(typed_decl.name, ViperTypedLocalDefinition(typed_decl.typ), typed_decl.pos, Some(p))
+                      case untyped_decl =>
+                        Definition(untyped_decl.name, ViperUntypedLocalDefinition, untyped_decl.pos, Some(p))
+                    }
                   case _ => Seq()
                 }
             } flatten
@@ -69,22 +86,35 @@ trait ProgramDefinitionsProvider {
         })
 
       case t: Domain =>
-        (Definition(t.name, "Domain", t.pos) +: (t.pos match {
+        (Definition(t.name, ViperDomain, t.pos) +: (t.pos match {
           case p: AbstractSourcePosition =>
             t.functions.flatMap { func =>
-              Definition(func.name, "Function", func.pos, Some(p)) +: (func.pos match {
+              Definition(func.name, ViperFunction, func.pos, Some(p)) +: (func.pos match {
                 case func_p: AbstractSourcePosition =>
-                  func.formalArgs.map { arg => Definition(if (arg.isInstanceOf[LocalVarDecl]) arg.asInstanceOf[LocalVarDecl].name else "unnamed parameter", "Argument", arg.pos, Some(func_p)) }
+                  func.formalArgs.map {
+                      case named_arg: LocalVarDecl =>
+                        Definition(named_arg.name, ViperArgument(named_arg.typ), named_arg.pos, Some(func_p))
+                      case unnamed_Arg =>
+                        Definition("unnamed_argument", ViperArgument(unnamed_Arg.typ), unnamed_Arg.pos, Some(func_p))
+                    }
                 case _ => Seq()
               })
             } ++ t.axioms.flatMap { ax =>
-              Definition(if (ax.isInstanceOf[NamedDomainAxiom]) ax.asInstanceOf[NamedDomainAxiom].name else "", "Axiom", ax.pos, Some(p)) +: (ax.pos match {
+              Definition(ax match {
+                case axiom: NamedDomainAxiom => axiom.name
+                case _ => ""
+              }, ViperAxiom, ax.pos, Some(p)) +: (ax.pos match {
                 case _: AbstractSourcePosition =>
                   ax.exp.deepCollect {
                     case scope:Scope with Positioned =>
                       scope.pos match {
                         case p: AbstractSourcePosition =>
-                          scope.scopedDecls.map { local_decl => Definition(local_decl.name, "Local", local_decl.pos, Some(p)) }
+                          scope.scopedDecls.map {
+                            case typed_decl: Declaration with Typed =>
+                              Definition(typed_decl.name, ViperTypedLocalDefinition(typed_decl.typ), typed_decl.pos, Some(p))
+                            case untyped_decl =>
+                              Definition(untyped_decl.name, ViperUntypedLocalDefinition, untyped_decl.pos, Some(p))
+                          }
                         case _ => Seq()
                       }
                   } flatten
@@ -94,7 +124,7 @@ trait ProgramDefinitionsProvider {
         })) ++ Seq()
 
       case t: Field =>
-        Seq(Definition(t.name, "Field", t.pos))
+        Seq(Definition(t.name, ViperField(t.typ), t.pos))
 
     } flatten) toList
   }

--- a/src/main/scala/viper/server/utility/ProgramDefinitionsProvider.scala
+++ b/src/main/scala/viper/server/utility/ProgramDefinitionsProvider.scala
@@ -6,11 +6,11 @@
 
 package viper.server.utility
 
-import scala.language.postfixOps
-import viper.silver.ast.{AbstractSourcePosition, Declaration, Domain, Field, Function, LocalVarDecl, Method,
-  NamedDomainAxiom, Positioned, Predicate, Program, Scope, Typed}
+import viper.silver.ast.{AbstractSourcePosition, Declaration, Domain, Field, Function, LocalVarDecl, Method, NamedDomainAxiom, Positioned, Predicate, Program, Scope, Typed}
 import viper.silver.frontend.SilFrontend
 import viper.silver.reporter._
+
+import scala.language.postfixOps
 
 trait ProgramDefinitionsProvider {
   protected val _frontend: SilFrontend


### PR DESCRIPTION
The goal o this PR is to pass **typed** information about program definitions to the IDE. To do this, we implement (more-or-less) proper serialization of Viper types (currently, into JSON), which might be useful by itself. 

This PR should be merged after [Silver PR 523](https://github.com/viperproject/silver/pull/523)