### PR TITLE
Fixes Cached Flag for Errors

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -275,7 +275,7 @@ jobs:
         run: |
           curl -L ${{ env.LINUX_BOOGIE_URL }} --output boogie-linux.zip
           unzip boogie-linux.zip -d boogie-linux
-          echo "$GITHUB_WORKSPACE/boogie-linux/binaries-linux/Boogie" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE/boogie-linux/binaries-linux" >> $GITHUB_PATH
           echo "BOOGIE_EXE=$GITHUB_WORKSPACE/boogie-linux/binaries-linux/Boogie" >> $GITHUB_ENV
         shell: bash
 
@@ -284,7 +284,7 @@ jobs:
         run: |
           curl -L ${{ env.MAC_BOOGIE_URL }} --output boogie-mac.zip
           unzip boogie-mac.zip -d boogie-mac
-          echo "$GITHUB_WORKSPACE/boogie-mac/binaries-osx/Boogie" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE/boogie-mac/binaries-osx" >> $GITHUB_PATH
           echo "BOOGIE_EXE=$GITHUB_WORKSPACE/boogie-mac/binaries-osx/Boogie" >> $GITHUB_ENV
         shell: bash
 
@@ -293,7 +293,7 @@ jobs:
         run: |
           curl -L ${{ env.WIN_BOOGIE_URL }} --output boogie-win.zip
           unzip boogie-win.zip -d boogie-win
-          echo "$GITHUB_WORKSPACE/boogie-win/binaries-win/Boogie.exe" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE/boogie-win/binaries-win" >> $GITHUB_PATH
           echo "BOOGIE_EXE=$GITHUB_WORKSPACE/boogie-win/binaries-win/Boogie.exe" >> $GITHUB_ENV
         shell: bash
 
@@ -307,7 +307,7 @@ jobs:
       - name: Z3 Version
         run: z3 -version
       - name: Boogie Version
-        run: boogie /version
+        run: Boogie /version
 
       # unfortunately, the JAR seems to be broken and discovering test suites (e.g. using `-w viper.server`) fails.
       # thus, the test suites have to be explicitly mentioned

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -275,6 +275,7 @@ jobs:
         run: |
           curl -L ${{ env.LINUX_BOOGIE_URL }} --output boogie-linux.zip
           unzip boogie-linux.zip -d boogie-linux
+          echo "$GITHUB_WORKSPACE/boogie-linux/binaries-linux/Boogie" >> $GITHUB_PATH
           echo "BOOGIE_EXE=$GITHUB_WORKSPACE/boogie-linux/binaries-linux/Boogie" >> $GITHUB_ENV
         shell: bash
 
@@ -283,6 +284,7 @@ jobs:
         run: |
           curl -L ${{ env.MAC_BOOGIE_URL }} --output boogie-mac.zip
           unzip boogie-mac.zip -d boogie-mac
+          echo "$GITHUB_WORKSPACE/boogie-mac/binaries-osx/Boogie" >> $GITHUB_PATH
           echo "BOOGIE_EXE=$GITHUB_WORKSPACE/boogie-mac/binaries-osx/Boogie" >> $GITHUB_ENV
         shell: bash
 
@@ -291,6 +293,7 @@ jobs:
         run: |
           curl -L ${{ env.WIN_BOOGIE_URL }} --output boogie-win.zip
           unzip boogie-win.zip -d boogie-win
+          echo "$GITHUB_WORKSPACE/boogie-win/binaries-win/Boogie.exe" >> $GITHUB_PATH
           echo "BOOGIE_EXE=$GITHUB_WORKSPACE/boogie-win/binaries-win/Boogie.exe" >> $GITHUB_ENV
         shell: bash
 

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -86,7 +86,7 @@ jobs:
   build:
     needs: prepare-matrix
     runs-on: ubuntu-latest
-    container: viperproject/viperserver:v3_z3_4.8.6
+    container: viperproject/viperserver:v4_z3_4.8.6
     strategy:
       # tests should not be stopped when they fail on one of the configurations:
       fail-fast: false
@@ -119,6 +119,8 @@ jobs:
         run: java --version
       - name: Z3 Version
         run: z3 -version
+      - name: Boogie Version
+        run: boogie /version
 
       - name: Create version file
         run: |
@@ -301,6 +303,8 @@ jobs:
         run: java --version
       - name: Z3 Version
         run: z3 -version
+      - name: Boogie Version
+        run: boogie /version
 
       # unfortunately, the JAR seems to be broken and discovering test suites (e.g. using `-w viper.server`) fails.
       # thus, the test suites have to be explicitly mentioned

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -216,6 +216,10 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
         name: ${{ fromJson(needs.prepare-matrix.outputs.matrix).name }}
     runs-on: ${{ matrix.os }}
+    env:
+      WIN_BOOGIE_URL: 'https://github.com/viperproject/boogie-builder/releases/latest/download/boogie-win.zip'
+      LINUX_BOOGIE_URL: 'https://github.com/viperproject/boogie-builder/releases/latest/download/boogie-linux.zip'
+      MAC_BOOGIE_URL: 'https://github.com/viperproject/boogie-builder/releases/latest/download/boogie-osx.zip'
     steps:
       # we need to checkout the repo to have access to the test files
       - name: Checkout ViperServer
@@ -262,6 +266,30 @@ jobs:
           unzip z3.zip -d z3/
           echo "$GITHUB_WORKSPACE/z3/z3-${{ env.Z3_VERSION }}-x64-win/bin" >> $GITHUB_PATH
           echo "Z3_EXE=$GITHUB_WORKSPACE/z3/z3-${{ env.Z3_VERSION }}-x64-win/bin/z3.exe" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Download Boogie (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          curl -L ${{ env.LINUX_BOOGIE_URL }} --output boogie-linux.zip
+          unzip boogie-linux.zip -d boogie-linux
+          echo "BOOGIE_EXE=$GITHUB_WORKSPACE/boogie-linux/binaries-linux/Boogie" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Download Boogie (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          curl -L ${{ env.MAC_BOOGIE_URL }} --output boogie-mac.zip
+          unzip boogie-mac.zip -d boogie-mac
+          echo "BOOGIE_EXE=$GITHUB_WORKSPACE/boogie-mac/binaries-osx/Boogie" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Download Boogie (Windows)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          curl -L ${{ env.WIN_BOOGIE_URL }} --output boogie-win.zip
+          unzip boogie-win.zip -d boogie-win
+          echo "BOOGIE_EXE=$GITHUB_WORKSPACE/boogie-win/binaries-win/Boogie.exe" >> $GITHUB_ENV
         shell: bash
 
       - name: Setup Java JDK

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,8 +32,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install sbt
-RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
+RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import && \
+    chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg && \
     apt-get update && \
     apt-get install -y sbt && \
     rm -rf /var/lib/apt/lists/*
@@ -54,6 +56,16 @@ RUN curl -L $Z3_URL --output /z3.zip && \
     rm -r /z3
 # executing `which z3` and setting Z3_EXE based on its result is unfortunately not possible, therefore it is hardcoded
 ENV Z3_EXE /usr/bin/z3
+
+# Install Boogie
+ENV BOOGIE_URL="https://github.com/viperproject/boogie-builder/releases/latest/download/boogie-linux.zip"
+ENV BOOGIE_BIN="binaries-linux/Boogie"
+RUN curl -L $BOOGIE_URL --output /boogie.zip && \
+    unzip /boogie.zip -d /boogie/ && \
+    rm /boogie.zip && \
+    ln -s /boogie/$BOOGIE_BIN /usr/bin/boogie
+# executing `which boogie` and setting BOOGIE_EXE based on its result is unfortunately not possible, therefore it is hardcoded
+ENV BOOGIE_EXE /usr/bin/boogie
 
 
 WORKDIR /

--- a/src/test/resources/viper/changed-axiom/version1.vpr
+++ b/src/test/resources/viper/changed-axiom/version1.vpr
@@ -1,0 +1,12 @@
+domain testDomain{
+    function func(): Bool
+
+    axiom unsound {
+        func() && !func()
+    }
+}
+
+method test() {
+    // succeeds due to unsound axiom above
+    assert false
+}

--- a/src/test/resources/viper/changed-axiom/version1.vpr
+++ b/src/test/resources/viper/changed-axiom/version1.vpr
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 domain testDomain{
     function func(): Bool
 

--- a/src/test/resources/viper/changed-axiom/version2.vpr
+++ b/src/test/resources/viper/changed-axiom/version2.vpr
@@ -1,0 +1,8 @@
+domain testDomain{
+    function func(): Bool
+}
+
+method test() {
+    // fails as expected
+    assert false
+}

--- a/src/test/resources/viper/changed-axiom/version2.vpr
+++ b/src/test/resources/viper/changed-axiom/version2.vpr
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 domain testDomain{
     function func(): Bool
 }

--- a/src/test/resources/viper/changed-function/version1.vpr
+++ b/src/test/resources/viper/changed-function/version1.vpr
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 function unsound(): Bool
     ensures false
 

--- a/src/test/resources/viper/changed-function/version1.vpr
+++ b/src/test/resources/viper/changed-function/version1.vpr
@@ -1,0 +1,7 @@
+function unsound(): Bool
+    ensures false
+
+method test() {
+    // succeeds due to unsound function above
+    assert false
+}

--- a/src/test/resources/viper/changed-function/version2.vpr
+++ b/src/test/resources/viper/changed-function/version2.vpr
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 method test() {
     // fails as expected
     assert false

--- a/src/test/resources/viper/changed-function/version2.vpr
+++ b/src/test/resources/viper/changed-function/version2.vpr
@@ -1,0 +1,4 @@
+method test() {
+    // fails as expected
+    assert false
+}

--- a/src/test/resources/viper/identical-versions/version1.vpr
+++ b/src/test/resources/viper/identical-versions/version1.vpr
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 method test() {
     assert false
 }

--- a/src/test/resources/viper/identical-versions/version1.vpr
+++ b/src/test/resources/viper/identical-versions/version1.vpr
@@ -1,0 +1,3 @@
+method test() {
+    assert false
+}

--- a/src/test/resources/viper/identical-versions/version2.vpr
+++ b/src/test/resources/viper/identical-versions/version2.vpr
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 method test() {
     assert false
 }

--- a/src/test/resources/viper/identical-versions/version2.vpr
+++ b/src/test/resources/viper/identical-versions/version2.vpr
@@ -1,0 +1,3 @@
+method test() {
+    assert false
+}


### PR DESCRIPTION
This PR correctly sets the `cached` flag for cached errors to `true`. Furthermore, several unit tests have been added including a check that cache results are not mixed up between backends (in an attempt to understand [Silicon Issue #550](https://github.com/viperproject/silver/issues/550) which is however not solved yet.
Additionally, Boogie has been added to the CI such that tests involving Carbon can be executed