### PR TITLE
Support for Viper files with long parsing times

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -6,6 +6,37 @@
 
 akka {
 
+  # loglevel = "DEBUG"
+
+  stream {
+    materializer {
+      # Cleanup leaked publishers and subscribers when they are not used within a given
+      # deadline
+      subscription-timeout {
+        # when the subscription timeout is reached one of the following strategies on
+        # the "stale" publisher:
+        # cancel - cancel it (via `onError` or subscribing to the publisher and
+        #          `cancel()`ing the subscription right away
+        # warn   - log a warning statement about the stale element (then drop the
+        #          reference to it)
+        # noop   - do nothing (not recommended)
+        mode = warn
+
+        # time after which a subscriber / publisher is considered stale and eligible
+        # for cancelation (see `akka.stream.subscription-timeout.mode`)
+        timeout = 5s # 5s is the default
+
+        # in the ViperServer case, this setting is relevant e.g. for streaming the messages
+        # that are in the queue. In particular, the queue would get completed (when the mode is set
+        # to `cancel`, which is Akka's default) if the messages do not get streamed within the
+        # timeout. Trying to enqueue any message into the queue after the timeout has been triggered
+        # results in exceptions. LA 15.5.2022: I've observed this for input files whose parsing takes
+        # longer than the configured timeout and using viper_client that only starts streaming messages
+        # after 10s (also more than the configured timeout).
+      }
+    }
+  }
+
   http {
 
     server {

--- a/src/main/scala/viper/server/vsi/VerificationServer.scala
+++ b/src/main/scala/viper/server/vsi/VerificationServer.scala
@@ -213,7 +213,7 @@ trait VerificationServer extends Post {
               }
           }
         }) flatMap {
-          case (ast_handle_maybe: Option[AstHandle[AST]], ver_handle: VerHandle) =>
+          case (ast_handle_maybe: Option[AstHandle[Option[AST]]], ver_handle: VerHandle) =>
             val ver_source = ver_handle match {
               case VerHandle(null, null, null, _) =>
                 /** There were no messages produced during verification. */


### PR DESCRIPTION
stops ViperServer from crashing if parsing takes longer than 5s and emits a warning instead if streaming parsing messages does not start within that time frame