### PR TITLE
Fixes Cache Initialization for HTTP Server

### DIFF
--- a/src/main/scala/viper/server/core/ViperCoreServer.scala
+++ b/src/main/scala/viper/server/core/ViperCoreServer.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.language.postfixOps
 
-class ViperCoreServer(val config: ViperConfig)(implicit val executor: VerificationExecutionContext) extends VerificationServer with ViperPost {
+abstract class ViperCoreServer(val config: ViperConfig)(implicit val executor: VerificationExecutionContext) extends VerificationServer with ViperPost {
 
   override type AST = Program
 
@@ -49,10 +49,10 @@ class ViperCoreServer(val config: ViperConfig)(implicit val executor: Verificati
     *
     * This function must be called before any other. Calling any other function before this one
     * will result in an IllegalStateException.
-    * */
+    */
   def start(): Future[Done] = {
     ViperCache.initialize(globalLogger, config.backendSpecificCache(), config.cacheFile.toOption)
-    super.start(config.maximumActiveJobs()) map { _ =>
+    start(config.maximumActiveJobs()) map { _ =>
       globalLogger.info(s"ViperCoreServer has started.")
       Done
     }

--- a/src/main/scala/viper/server/frontends/http/ViperHttpServer.scala
+++ b/src/main/scala/viper/server/frontends/http/ViperHttpServer.scala
@@ -32,7 +32,9 @@ class ViperHttpServer(config: ViperConfig)(executor: VerificationExecutionContex
 
   override def start(): Future[Done] = {
     port = config.port.toOption.getOrElse(0) // 0 causes HTTP server to automatically select a free port
-    super.start(config.maximumActiveJobs()).map({ _ =>
+    // we call here `ViperCoreServer.start()` (which internally calls `VerificationServer.start(activeJobs)`)
+    // Note that `VerificationServer.start(activeJobs)` is overridden in VerificationServerHttp.
+    super.start().map({ _ =>
       println(s"ViperServer online at http://localhost:$port")
       Done
     })(executor)

--- a/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
+++ b/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
@@ -15,13 +15,13 @@ import viper.server.ViperConfig
 import viper.server.core.{VerificationExecutionContext, ViperBackendConfig, ViperCoreServer}
 import viper.server.utility.Helpers.{getArgListFromArgString, validateViperFile}
 import viper.server.vsi.VerificationProtocol.StopVerification
-import viper.server.vsi.{VerJobId, VerificationServer}
+import viper.server.vsi.{DefaultVerificationServerStart, VerJobId}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class ViperServerService(config: ViperConfig)(override implicit val executor: VerificationExecutionContext)
-  extends ViperCoreServer(config)(executor) with VerificationServer {
+  extends ViperCoreServer(config)(executor) with DefaultVerificationServerStart {
 
   def verifyWithCommand(command: String, localLogger: Option[Logger] = None): VerJobId = {
     val logger = combineLoggers(localLogger)

--- a/src/main/scala/viper/server/vsi/HTTP.scala
+++ b/src/main/scala/viper/server/vsi/HTTP.scala
@@ -65,7 +65,7 @@ trait VerificationServerHttp extends VerificationServer with CustomizableHttp {
 
   def setRoutes(): Route
 
-  private var stoppedPromise: Promise[Done] = _
+  private val stoppedPromise: Promise[Done] = Promise()
   var bindingFuture: Future[Http.ServerBinding] = _
 
   /**
@@ -76,7 +76,6 @@ trait VerificationServerHttp extends VerificationServer with CustomizableHttp {
   override def start(active_jobs: Int): Future[Done] = {
     ast_jobs = new JobPool("AST-pool", active_jobs)
     ver_jobs = new JobPool("Verification-pool", active_jobs)
-    stoppedPromise = Promise()
     bindingFuture = Http().newServerAt("localhost", port).bindFlow(setRoutes())
     _termActor = system.actorOf(Terminator.props(ast_jobs, ver_jobs, Some(bindingFuture)), "terminator")
     bindingFuture.map { serverBinding =>

--- a/src/main/scala/viper/server/vsi/VerificationServer.scala
+++ b/src/main/scala/viper/server/vsi/VerificationServer.scala
@@ -63,14 +63,10 @@ trait VerificationServer extends Post {
     * This function must be called before any other. Calling any other function before this one
     * will result in an IllegalStateException.
     * The returned future resolves when the server has been started.
-    * */
-  def start(active_jobs: Int): Future[Done] = {
-    ast_jobs = new JobPool("VSI-AST-pool", active_jobs)
-    ver_jobs = new JobPool("VSI-Verification-pool", active_jobs)
-    _termActor = system.actorOf(Terminator.props(ast_jobs, ver_jobs), "terminator")
-    isRunning = true
-    Future.successful(Done)
-  }
+    *
+    * Note that a default implementation is provided in DefaultVerificationServerStart
+    */
+  def start(active_jobs: Int): Future[Done]
 
   protected def initializeProcess[S <: JobId, T <: JobHandle : ClassTag]
       (pool: JobPool[S, T],
@@ -277,5 +273,15 @@ trait VerificationServer extends Post {
       } toList
     val overall_interrupt_future: Future[List[String]] = Future.sequence(interrupt_future_list)
     overall_interrupt_future
+  }
+}
+
+trait DefaultVerificationServerStart extends VerificationServer {
+  override def start(active_jobs: Int): Future[Done] = {
+    ast_jobs = new JobPool("VSI-AST-pool", active_jobs)
+    ver_jobs = new JobPool("VSI-Verification-pool", active_jobs)
+    _termActor = system.actorOf(Terminator.props(ast_jobs, ver_jobs), "terminator")
+    isRunning = true
+    Future.successful(Done)
   }
 }

--- a/src/test/scala/viper/server/core/CoreServerSpec.scala
+++ b/src/test/scala/viper/server/core/CoreServerSpec.scala
@@ -18,7 +18,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import viper.server.ViperConfig
 import viper.server.frontends.lsp.{ClientCoordinator, FileManager, GetIdentifierResponse, GetViperFileEndingsResponse, HintMessage, IdeLanguageClient, LogParams, StateChangeParams, UnhandledViperServerMessageTypeParams, VerificationNotStartedParams, ViperServerService}
 import viper.server.utility.AstGenerator
-import viper.server.vsi.{JobNotFoundException, VerJobId}
+import viper.server.vsi.{DefaultVerificationServerStart, JobNotFoundException, VerJobId}
 import viper.silver.ast
 import viper.silver.ast.{AbstractSourcePosition, HasLineColumn, Program}
 import viper.silver.logger.SilentLogger
@@ -94,7 +94,7 @@ class CoreServerSpec extends AnyWordSpec with Matchers {
   }
 
   implicit val viperCoreServerFactory: (ViperConfig, VerificationExecutionContext) => ViperCoreServer =
-    (config, context) => new ViperCoreServer(config)(context)
+    (config, context) => new ViperCoreServer(config)(context) with DefaultVerificationServerStart
   val viperServerServiceFactory: (ViperConfig, VerificationExecutionContext) => ViperServerService =
     (config, context) => new ViperServerService(config)(context)
 


### PR DESCRIPTION
`ViperHttpServer` did not call `start()` on `ViperCoreServer` and instead directly called `start(active_jobs)` on `VerificationServer`. This resulted in an uninitialized cache and thus in an exception whenever ViperServer tries to store a verification result in the cache after a verification.
This PR fixes #111 by making `ViperHttpServer` call `ViperCoreServer.start()` and slightly changing the inheritance such that `VerificationServerHttp` can still configure the server startup (i.e. to bind the HTTP server).