### PR TITLE
Improve Verification Aborts

### DIFF
--- a/src/main/scala/viper/server/frontends/lsp/ClientCoordinator.scala
+++ b/src/main/scala/viper/server/frontends/lsp/ClientCoordinator.scala
@@ -114,6 +114,7 @@ class ClientCoordinator(val server: ViperServerService)(implicit executor: Verif
     Option(_files.get(uri))
       .map(fm => fm.stopVerification()
         .map(_ => {
+          logger.trace(s"stopVerification has completed for ${fm.uri}")
           val params = StateChangeParams(Ready.id, verificationCompleted = 0, verificationNeeded = 0, uri = uri)
           sendStateChangeNotification(params, Some(fm))
           true

--- a/src/main/scala/viper/server/frontends/lsp/FileManager.scala
+++ b/src/main/scala/viper/server/frontends/lsp/FileManager.scala
@@ -158,6 +158,9 @@ class FileManager(coordinator: ClientCoordinator, file_uri: String)(implicit exe
     }
 
     override def receive: PartialFunction[Any, Unit] = {
+      case m if is_aborting =>
+        coordinator.logger.debug(s"ignoring message because we are aborting: $m")
+
       case ProgramOutlineReport(members) =>
         symbolInformation = ArrayBuffer()
         members.foreach(m => {

--- a/src/main/scala/viper/server/vsi/HTTP.scala
+++ b/src/main/scala/viper/server/vsi/HTTP.scala
@@ -62,6 +62,7 @@ sealed trait CustomizableHttp extends BasicHttp {
   * responses as type [[ToResponseMarshallable]].
   * */
 trait VerificationServerHttp extends VerificationServer with CustomizableHttp {
+  import scala.language.postfixOps
 
   def setRoutes(): Route
 


### PR DESCRIPTION
As observed in [Viper-IDE #370](https://github.com/viperproject/viper-ide/issues/370), a subsequent verification might be affected by an earlier abort.
We have observed that ViperServer keeps sending messages to Viper-IDE even though the abort has finished. The probable reason is that the propagation of messages is delayed. Thus, this PR performs these two contributions:
- skip all messages after performing an abort such that a client does not confuse them belonging to a potential subsequent verification job
- abort not just the verification job but also the AST building job