### PR TITLE
Keep Nightly Release Tags

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -332,6 +332,7 @@ jobs:
           release_name: Nightly Release ${{ env.TAG_NAME }}
           body_path: versions.txt
           keep_num: 1 # keep the previous nightly release such that there are always two
+          keep_tags: true
 
       - name: Upload ViperServer skinny jars
         if: env.MATCHING_RELEASE != 'true'


### PR DESCRIPTION
While nightly releases should be deleted, their corresponding tags should remain, as proposed by @Aurel300. This achieves a great tradeoff between documentation (i.e., which Silver/Carbon/Silicon commits were used) and the number of releases showing up in the UI because tags are listed separately. 