### PR TITLE
viper-data-collection changes

### DIFF
--- a/src/main/scala/viper/server/core/VerificationWorker.scala
+++ b/src/main/scala/viper/server/core/VerificationWorker.scala
@@ -406,7 +406,6 @@ class ViperBackend(val backendName: String, private val _frontend: SilFrontend, 
     val s = new ViperProgramSubmitter(_frontend) {
       override def originalFrontend: String = "ViperServer"
     }
-    s.setName(programId.split("/").last)
     s.setProgram(_ast)
     s
   }


### PR DESCRIPTION
This PR should only be accepted after this [Silicon PR](https://github.com/viperproject/silicon/pull/799) and [Carbon PR](https://github.com/viperproject/carbon/pull/491) have been merged and the submodules updated.

Added code to `ViperBackend` to submit programs to the [viper-data-collection backend](https://github.com/viperproject/viper-data-collection) if `—submitForEvaluation` is passed as an argument to the SilFrontend.