### PR TITLE
Adapts to CI to keep nightly releases

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Create nightly release
         if: env.MATCHING_RELEASE != 'true'
         id: create_release
-        uses: viperproject/create-nightly-release@v1
+        uses: actions/create-release@v1
         env:
           # This token is provided by Actions, you do not need to create your own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -332,8 +332,8 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           release_name: Nightly Release ${{ env.TAG_NAME }}
           body_path: versions.txt
-          keep_num: 1 # keep the previous nightly release such that there are always two
-          keep_tags: true
+          draft: false
+          prerelease: true
 
       - name: Upload ViperServer skinny jars
         if: env.MATCHING_RELEASE != 'true'

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -357,25 +357,6 @@ jobs:
           asset_name: viperserver.jar
           asset_content_type: application/octet-stream
 
-      - name: Trigger Viper-IDE CI
-        if: env.MATCHING_RELEASE != 'true'
-        run: |
-          curl --fail --request POST \
-          --user 'viper-admin:${{ secrets.VIPER_ADMIN_TOKEN }}' \
-          --header 'Accept: application/vnd.github.v3+json' \
-          --url 'https://api.github.com/repos/viperproject/viper-ide/actions/workflows/test.yml/dispatches' \
-          --data "{ \
-            \"ref\":\"master\", \
-            \"inputs\":{ \
-              \"type\":\"nightly\", \
-              \"viperserver_tag_name\":\"${{ env.TAG_NAME }}\", \
-              \"boogie_tag_name\":\"latest\", \
-              \"z3_version\":\"${{ env.Z3_VERSION }}\", \
-              \"tag_name\":\"${{ env.TAG_NAME }}\", \
-              \"release_name\":\"Nightly Release ${{ env.TAG_NAME }}\" \
-            } \
-          }"
-
 
   create-stable-release:
     needs: test


### PR DESCRIPTION
Since Viper-IDE (cf. [Viper-IDE PR #434](https://github.com/viperproject/viper-ide/pull/434))is built with respect to a fixed ViperServer release, we should not delete old nightly releases.

Additionally, this PR removes triggering of Viper-IDE's CI. Instead, we will create a periodic CI job to compare and fetch the latest ViperServer release.