### PR TITLE
Add Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ter.bat
 ver.bat
 .bsp/
 logs/
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719531801,
+        "narHash": "sha256-EHrZuCNR1IJhq9H1m6PFnoYT8oz9JG0/mra22vvqYmU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "49f04c74c356bc1d6dbea4b1b109a4165daf3249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "sbt": "sbt"
+      }
+    },
+    "sbt": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698464090,
+        "narHash": "sha256-Pnej7WZIPomYWg8f/CZ65sfW85IfIUjYhphMMg7/LT0=",
+        "owner": "zaninime",
+        "repo": "sbt-derivation",
+        "rev": "6762cf2c31de50efd9ff905cbcc87239995a4ef9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zaninime",
+        "repo": "sbt-derivation",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "HTTP server that manages verification requests to different tools from the Viper tool stack.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    sbt = {
+      url = "github:zaninime/sbt-derivation";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, sbt }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forAllSystems = function: nixpkgs.lib.genAttrs supportedSystems
+      (system: function (import nixpkgs { inherit system; }));
+  in {
+    packages = forAllSystems (pkgs: {
+      default = sbt.lib.mkSbtDerivation {
+        inherit pkgs;
+        overrides = { sbt = pkgs.sbt.override { jre = pkgs.jdk11_headless; }; };
+        pname = "viperserver";
+        src = ./.;
+        depsSha256 = "sha256-iJHPSJkxjFWVEmXFXX16OpqKOuSSE/qIxUpDfRbb/Fk=";
+        version = "${self.tag or "${self.lastModifiedDate}.${self.shortRev or "dirty"}"}";
+        buildInputs = with pkgs; [ z3 boogie ];
+        depsWarmupCommand = "sbt update";
+        buildPhase = "sbt assembly";
+        installPhase = ''mkdir -p $out/server && mkdir -p $out/boogie/Binaries/ &&
+          cp target/scala-2.13/viperserver.jar $out/server/viperserver.jar &&
+          cp -r ${pkgs.z3} $out/z3 &&
+          cp ${pkgs.boogie}/bin/boogie $out/boogie/Binaries/Boogie'';
+        Z3_EXE = "${pkgs.z3}/bin/z3";
+        BOOGIE_EXE = "${pkgs.boogie}/bin/boogie";
+      };
+    });
+  };
+}


### PR DESCRIPTION
Currently, the [Prusti repo](https://github.com/viperproject/prusti-dev) has a Nix flake, but this flake does not work because it downloads Viper from the download link. This means that whenever a new version of Viper is released and the SHA256 hash changes, the Prusti flake will fail to build. By introducing a flake in the Viper repository as well, the Prusti flake will be able to refer to a specific version of Viper, and a new release of Viper will not break the Prusti flake.

Notes:
 - Nix does not work well with submodules. In order to copy the submodules to the Nix store, you have to explicity specify the target as `"git+file://$(pwd)?submodules=1"`. For example, instead of `nix build .`, you would run `nix build "git+file://$(pwd)?submodules=1"`. In the future, if Viper were to switch to using Nix for all development and CI, the submodules could be removed and instead the Carbon, Silicon, and Silver repositories could be used as flake inputs, removing the need for this.
 - `nix develop "git+file://$(pwd)?submodules=1"` opens a development shell with sbt and JDK 11 in the PATH, and the Z3_EXE and BOOGIE_EXE environment variables are set.
 - Currently, the flake only builds the fat jar, since that is all Prusti needs. An additional package could be added in the future to the flake to build the skinny jars instead.