### PR TITLE
Unique name for the Terminator actor

### DIFF
--- a/src/main/scala/viper/server/vsi/HTTP.scala
+++ b/src/main/scala/viper/server/vsi/HTTP.scala
@@ -78,7 +78,7 @@ trait VerificationServerHttp extends VerificationServer with CustomizableHttp {
     ast_jobs = new JobPool("AST-pool", active_jobs)
     ver_jobs = new JobPool("Verification-pool", active_jobs)
     bindingFuture = Http().newServerAt("localhost", port).bindFlow(setRoutes())
-    _termActor = system.actorOf(Terminator.props(ast_jobs, ver_jobs, Some(bindingFuture)), "terminator")
+    _termActor = system.actorOf(Terminator.props(ast_jobs, ver_jobs, Some(bindingFuture)), Terminator.GetNextTerminatorName)
     bindingFuture.map { serverBinding =>
       val newPort = serverBinding.localAddress.getPort
       if (port == 0) {

--- a/src/main/scala/viper/server/vsi/Terminator.scala
+++ b/src/main/scala/viper/server/vsi/Terminator.scala
@@ -10,6 +10,7 @@ import akka.actor.{Actor, Props}
 import akka.http.scaladsl.Http
 import viper.server.core.VerificationExecutionContext
 
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.Future
 
 // --- Actor: Terminator ---
@@ -18,6 +19,14 @@ import scala.concurrent.Future
 object Terminator {
   case object Exit
   case class WatchJobQueue(jid: JobId, handle: JobHandle)
+
+  // Each server start creates a new Terminator actor. Akka does not like non-unique actor names.
+  // Thus, we increment a counter to ensure unique names for our Terminator actors even though at no point
+  // two of them should be active.
+  // Without this counter, the issue of non-unique actor names occurs in testing contexts as, e.g. in Gobra's tests,
+  // we start a new ViperServer instance for each testcase that needs it.
+  private val terminatorCounter = new AtomicInteger(0)
+  val GetNextTerminatorName: String = s"terminator${terminatorCounter.getAndIncrement()}"
 
   def props[R](ast_jobs: JobPool[AstJobId, AstHandle[R]],
                ver_jobs: JobPool[VerJobId, VerHandle],

--- a/src/main/scala/viper/server/vsi/Terminator.scala
+++ b/src/main/scala/viper/server/vsi/Terminator.scala
@@ -26,7 +26,7 @@ object Terminator {
   // Without this counter, the issue of non-unique actor names occurs in testing contexts as, e.g. in Gobra's tests,
   // we start a new ViperServer instance for each testcase that needs it.
   private val terminatorCounter = new AtomicInteger(0)
-  val GetNextTerminatorName: String = s"terminator${terminatorCounter.getAndIncrement()}"
+  def GetNextTerminatorName: String = s"terminator${terminatorCounter.getAndIncrement()}"
 
   def props[R](ast_jobs: JobPool[AstJobId, AstHandle[R]],
                ver_jobs: JobPool[VerJobId, VerHandle],

--- a/src/main/scala/viper/server/vsi/VerificationServer.scala
+++ b/src/main/scala/viper/server/vsi/VerificationServer.scala
@@ -280,7 +280,7 @@ trait DefaultVerificationServerStart extends VerificationServer {
   override def start(active_jobs: Int): Future[Done] = {
     ast_jobs = new JobPool("VSI-AST-pool", active_jobs)
     ver_jobs = new JobPool("VSI-Verification-pool", active_jobs)
-    _termActor = system.actorOf(Terminator.props(ast_jobs, ver_jobs), "terminator")
+    _termActor = system.actorOf(Terminator.props(ast_jobs, ver_jobs), Terminator.GetNextTerminatorName)
     isRunning = true
     Future.successful(Done)
   }


### PR DESCRIPTION
I've observed errors created by Akka complaining about non-unique names for instances of the Terminator actor when using ViperServer in Gobra's unit tests. A Terminator actor instance is only used during the lifetime of a ViperServer instance but we use a separate ViperServer instance for each unit test that needs such an instance and Akka is apparently not happy that we reuse the same name.
This PR addresses this issue by using a unique name for each Terminator instance.