### PR TITLE
Update SBT Dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,6 @@ lazy val carbon = project in file("carbon")
 lazy val server = (project in file("."))
     .dependsOn(silicon % "compile->compile;test->test")
     .dependsOn(carbon % "compile->compile;test->test")
-    .enablePlugins(JavaAppPackaging)
     .settings(
         // General settings
         name := "ViperServer",

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ lazy val carbon = project in file("carbon")
 lazy val server = (project in file("."))
     .dependsOn(silicon % "compile->compile;test->test")
     .dependsOn(carbon % "compile->compile;test->test")
+    .enablePlugins(JavaAppPackaging)
     .settings(
         // General settings
         name := "ViperServer",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.6")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,5 @@
 // http://creativecommons.org/publicdomain/zero/1.0/
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")


### PR DESCRIPTION
The CI encountered today strange errors when trying to initialize `sbt` ([example](https://github.com/viperproject/viperserver/actions/runs/14302944041/job/40082415933)). It seems that all 3 sbt plugins (`com.eed3si9n:sbt-assembly`, `com.typesafe.sbt:sbt-native-package`, and `com.eed3si9n:sbt-buildinfo`) result in `409` errors when trying to download them. While  a `409` error hints at some server-internal conflict related to such a dependency, it remains unclear why this got triggered today.
This PR updates these dependencies.