### PR TITLE
Add JSON serialization for new message types and improve code quality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,12 @@ lazy val server = (project in file("."))
         // classpath used by Scala's reflection.
         fork := true,
 
+        // Compilation settings
+        // Note that the remaining scalac options (e.g. -deprecation, -feature, and -Wunused) are
+        // inherited from Silver's `ThisBuild / scalacOptions`. Treating warnings as errors is
+        // scoped to this project such that the backends remain unaffected.
+        scalacOptions += "-Xfatal-warnings", // Treat warnings as errors to guarantee code quality in future changes
+
         libraryDependencies += "net.liftweb" %% "lift-json" % "3.5.0",
         libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.6.10",
         libraryDependencies += "com.typesafe.akka" %% "akka-http-spray-json" % "10.2.1",

--- a/src/main/scala/viper/server/core/MessageReportingTask.scala
+++ b/src/main/scala/viper/server/core/MessageReportingTask.scala
@@ -8,8 +8,7 @@ package viper.server.core
 
 import ch.qos.logback.classic.Logger
 import viper.server.vsi.MessageStreamingTask
-import viper.silver.reporter.{Entity, EntityFailureMessage, EntitySuccessMessage, Message, PluginAwareReporter, Time, VerificationResultMessage}
-import viper.silver.verifier.{Success, VerificationResult}
+import viper.silver.reporter.{EntityFailureMessage, EntitySuccessMessage, Message, PluginAwareReporter}
 
 trait MessageReportingTask[T] extends MessageStreamingTask[T] with ViperPost {
 

--- a/src/main/scala/viper/server/frontends/http/ViperRequests.scala
+++ b/src/main/scala/viper/server/frontends/http/ViperRequests.scala
@@ -21,5 +21,5 @@ object ViperRequests extends akka.http.scaladsl.marshallers.sprayjson.SprayJsonS
   // Other requests go below this line.
   case class AlloyGenerationRequest(arg: String, solver: String)
 
-  implicit val generateStuff = jsonFormat2(AlloyGenerationRequest.apply)
+  implicit val generateStuff: RootJsonFormat[AlloyGenerationRequest] = jsonFormat2(AlloyGenerationRequest.apply)
 }

--- a/src/main/scala/viper/server/frontends/http/jsonWriters/ViperIDEProtocol.scala
+++ b/src/main/scala/viper/server/frontends/http/jsonWriters/ViperIDEProtocol.scala
@@ -225,6 +225,13 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
       "cached" -> obj.cached.toJson)
   })
 
+  /** `CachedEntityMessage` is not sealed, so backends may provide their own implementations for
+    * which only the fields of `VerificationResultMessage` are known. */
+  implicit val cachedEntityMessage_writer: RootJsonFormat[CachedEntityMessage] = lift(new RootJsonWriter[CachedEntityMessage] {
+    override def write(obj: CachedEntityMessage): JsValue = JsObject(
+      "result" -> obj.result.toJson)
+  })
+
   implicit val astConstructionMessage_writer: RootJsonFormat[AstConstructionResultMessage] = lift(new RootJsonWriter[AstConstructionResultMessage] {
     override def write(obj: AstConstructionResultMessage): JsValue = JsObject(
       "status" -> (obj match {
@@ -295,9 +302,7 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
           case c: EntityFailureMessage => c.toJson
           case d: EntitySuccessMessage => d.toJson
           case e: BranchFailureMessage => e.toJson
-          // `CachedEntityMessage` is not sealed, so backends may provide their own implementations
-          // for which only the fields of `VerificationResultMessage` are known.
-          case f: CachedEntityMessage => JsObject("result" -> f.result.toJson)
+          case f: CachedEntityMessage => f.toJson
         }))
     }
   })

--- a/src/main/scala/viper/server/frontends/http/jsonWriters/ViperIDEProtocol.scala
+++ b/src/main/scala/viper/server/frontends/http/jsonWriters/ViperIDEProtocol.scala
@@ -83,6 +83,7 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
       case NoPosition => JsString(obj.toString)
       case sp: AbstractSourcePosition => sp.toJson
       case hlc: HasLineColumn => JsString(s"${hlc.line}:${hlc.column}")
+      case vp: VirtualPosition => JsString(vp.toString)
     }
   })
 
@@ -133,6 +134,11 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
         JsObject(
           "type" -> JsString("application_entry"),
           "value" -> a.toJson
+        )
+      case UnspecifiedEntry =>
+        JsObject(
+          "type" -> JsString("unspecified_entry"),
+          "value" -> JsString(UnspecifiedEntry.toString)
         )
     }
   })
@@ -212,6 +218,13 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
       "cached" -> obj.cached.toJson)
   })
 
+  implicit val branchFailureMessage_writer: RootJsonFormat[BranchFailureMessage] = lift(new RootJsonWriter[BranchFailureMessage] {
+    override def write(obj: BranchFailureMessage): JsValue = JsObject(
+      "entity" -> obj.concerning.toJson,
+      "result" -> obj.result.toJson,
+      "cached" -> obj.cached.toJson)
+  })
+
   implicit val astConstructionMessage_writer: RootJsonFormat[AstConstructionResultMessage] = lift(new RootJsonWriter[AstConstructionResultMessage] {
     override def write(obj: AstConstructionResultMessage): JsValue = JsObject(
       "status" -> (obj match {
@@ -281,6 +294,10 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
           case b: OverallSuccessMessage => b.toJson
           case c: EntityFailureMessage => c.toJson
           case d: EntitySuccessMessage => d.toJson
+          case e: BranchFailureMessage => e.toJson
+          // `CachedEntityMessage` is not sealed, so backends may provide their own implementations
+          // for which only the fields of `VerificationResultMessage` are known.
+          case f: CachedEntityMessage => JsObject("result" -> f.result.toJson)
         }))
     }
   })
@@ -473,6 +490,33 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
       )
   })
 
+  implicit val benchmarkingMessage_writer: RootJsonFormat[BenchmarkingMessage] = lift(new RootJsonWriter[BenchmarkingMessage] {
+    override def write(obj: BenchmarkingMessage): JsObject = JsObject(
+      "category" -> JsString(obj.category),
+      "payload" -> JsString(obj.payload))
+  })
+
+  implicit val blockReachedMessage_writer: RootJsonFormat[BlockReachedMessage] = lift(new RootJsonWriter[BlockReachedMessage] {
+    override def write(obj: BlockReachedMessage): JsObject = JsObject(
+      "method_name" -> JsString(obj.methodName),
+      "label" -> JsString(obj.label),
+      "path_id" -> JsNumber(obj.pathId))
+  })
+
+  implicit val blockFailureMessage_writer: RootJsonFormat[BlockFailureMessage] = lift(new RootJsonWriter[BlockFailureMessage] {
+    override def write(obj: BlockFailureMessage): JsObject = JsObject(
+      "method_name" -> JsString(obj.methodName),
+      "label" -> JsString(obj.label),
+      "path_id" -> JsNumber(obj.pathId))
+  })
+
+  implicit val pathProcessedMessage_writer: RootJsonFormat[PathProcessedMessage] = lift(new RootJsonWriter[PathProcessedMessage] {
+    override def write(obj: PathProcessedMessage): JsObject = JsObject(
+      "method_name" -> JsString(obj.methodName),
+      "path_id" -> JsNumber(obj.pathId),
+      "result" -> JsString(obj.result))
+  })
+
   implicit val message_writer: RootJsonFormat[Message] = lift(new RootJsonWriter[Message] {
     override def write(obj: Message): JsValue = JsObject(
       "msg_type" -> JsString(obj.name),
@@ -495,6 +539,10 @@ object ViperIDEProtocol extends akka.http.scaladsl.marshallers.sprayjson.SprayJs
         case v: VerificationTerminationMessage => v.toJson
         case p: PProgramReport => p.semanticAnalysisSuccess.toJson
         case w: WarningsDuringVerification => w.toJson
+        case n: BenchmarkingMessage => n.toJson
+        case l: BlockReachedMessage => l.toJson
+        case k: BlockFailureMessage => k.toJson
+        case t: PathProcessedMessage => t.toJson
       }))
   })
 

--- a/src/main/scala/viper/server/frontends/lsp/Common.scala
+++ b/src/main/scala/viper/server/frontends/lsp/Common.scala
@@ -10,7 +10,6 @@ import java.net.URI
 import java.nio.file.{Path, Paths}
 
 import org.eclipse.lsp4j.{Position, Range}
-import scala.collection.mutable.ArrayBuffer
 import viper.silver.ast
 import org.eclipse.lsp4j.Location
 

--- a/src/main/scala/viper/server/frontends/lsp/DataProtocol.scala
+++ b/src/main/scala/viper/server/frontends/lsp/DataProtocol.scala
@@ -6,7 +6,7 @@
 
 package viper.server.frontends.lsp
 
-import org.eclipse.lsp4j.{Diagnostic, ParameterInformation, Position, Range}
+import org.eclipse.lsp4j.{ParameterInformation, Range}
 import viper.silver.reporter
 
 object VerificationSuccess extends Enumeration {

--- a/src/main/scala/viper/server/frontends/lsp/Receiver.scala
+++ b/src/main/scala/viper/server/frontends/lsp/Receiver.scala
@@ -15,6 +15,7 @@ import viper.server.ViperConfig
 import viper.server.core.VerificationExecutionContext
 import viper.viperserver.BuildInfo
 
+import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
@@ -178,6 +179,9 @@ trait TextDocumentReceiver extends StandardReceiver with TextDocumentService {
   // Optional
   //////////////////
 
+  // `SymbolInformation` is deprecated but the LSP4J interface still requires it as the left
+  // alternative of the returned `Either`.
+  @nowarn("cat=deprecation")
   override def documentSymbol(params: DocumentSymbolParams) = {
     // This happens for every edit, so `trace` to avoid spam
     coordinator.logger.trace(s"[Req: textDocument/documentSymbol] ${params.toString()}")

--- a/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
+++ b/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
@@ -14,7 +14,6 @@ import ch.qos.logback.classic.Logger
 import viper.server.ViperConfig
 import viper.server.core.{VerificationExecutionContext, ViperBackendConfig, ViperCoreServer}
 import viper.server.utility.ReformatterAstGenerator
-import viper.server.utility.Helpers.{getArgListFromArgString, validateViperFile}
 import viper.server.utility.Helpers.validateViperFile
 import viper.server.vsi.VerificationProtocol.{StopAstConstruction, StopVerification}
 import viper.server.vsi.{AstJobId, DefaultVerificationServerStart, VerHandle, VerJobId}

--- a/src/main/scala/viper/server/frontends/lsp/file/Manager.scala
+++ b/src/main/scala/viper/server/frontends/lsp/file/Manager.scala
@@ -7,6 +7,7 @@
 package viper.server.frontends.lsp.file
 
 import java.nio.file.Path
+import ch.qos.logback.classic.Logger
 import org.eclipse.lsp4j.{PublishDiagnosticsParams, Range}
 import viper.server.frontends.lsp.ClientCoordinator
 
@@ -28,7 +29,7 @@ trait Manager {
   val file: PathInfo
   val content: FileContent
   val coordinator: ClientCoordinator
-  implicit def logger = coordinator.logger
+  implicit def logger: Logger = coordinator.logger
 
   def addContainer(c: utility.LspContainer[_, _, _, _, _]): Unit
   def resetContainers(first: Boolean): Unit

--- a/src/main/scala/viper/server/utility/ibm/Socket.scala
+++ b/src/main/scala/viper/server/utility/ibm/Socket.scala
@@ -42,7 +42,7 @@ object Socket {
     * TODO: check license
     *
     * @return a free port number on localhost
-    * @throws IllegalStateException if unable to find a free port
+    * @throws java.lang.IllegalStateException if unable to find a free port
     */
   def findFreePort: Int = {
     var socket: ServerSocket = null

--- a/src/main/scala/viper/server/vsi/HTTP.scala
+++ b/src/main/scala/viper/server/vsi/HTTP.scala
@@ -59,7 +59,7 @@ sealed trait CustomizableHttp extends BasicHttp {
   *
   * The VerificationServer-specific functionality will need to be implemented for each individual
   * server. In particular, this means providing a protocol that returns the VerificationServer's
-  * responses as type [[ToResponseMarshallable]].
+  * responses as type `akka.http.scaladsl.marshalling.ToResponseMarshallable`.
   * */
 trait VerificationServerHttp extends VerificationServer with CustomizableHttp {
   import scala.language.postfixOps

--- a/src/main/scala/viper/server/vsi/JobActor.scala
+++ b/src/main/scala/viper/server/vsi/JobActor.scala
@@ -49,7 +49,9 @@ class JobActor[T](private val id: JobId) extends Actor {
   }
 
   override def receive: PartialFunction[Any, Unit] = {
-    case req: StartProcessRequest[T] =>
+    // The type argument cannot be checked at runtime because of erasure. This is safe because this
+    // actor only ever receives requests parameterized with its own type argument.
+    case req: StartProcessRequest[T @unchecked] =>
       req match {
         case _: ConstructAst[T] =>
           //println(">>> JobActor received request ConstructAst")

--- a/src/main/scala/viper/server/vsi/Terminator.scala
+++ b/src/main/scala/viper/server/vsi/Terminator.scala
@@ -11,6 +11,7 @@ import akka.http.scaladsl.Http
 import viper.server.core.VerificationExecutionContext
 
 import java.util.concurrent.atomic.AtomicInteger
+import scala.annotation.unused
 import scala.concurrent.Future
 
 // --- Actor: Terminator ---
@@ -35,8 +36,10 @@ object Terminator {
   = Props(new Terminator(ast_jobs, ver_jobs, bindingFuture)(ctx))
 }
 
-class Terminator[R](ast_jobs: JobPool[AstJobId, AstHandle[R]],
-                    ver_jobs: JobPool[VerJobId, VerHandle],
+/** The job pools are currently unused; they are kept as parameters for the not yet implemented
+  * handling of [[Terminator.WatchJobQueue]] messages. */
+class Terminator[R](@unused ast_jobs: JobPool[AstJobId, AstHandle[R]],
+                    @unused ver_jobs: JobPool[VerJobId, VerHandle],
                     bindingFuture: Option[Future[Http.ServerBinding]])
                 (implicit val ctx: VerificationExecutionContext) extends Actor {
 

--- a/src/main/scala/viper/server/vsi/VerificationServer.scala
+++ b/src/main/scala/viper/server/vsi/VerificationServer.scala
@@ -92,6 +92,9 @@ trait VerificationServer extends Post {
           new_jid match {
             case _: VerJobId =>
               Future.successful(VerHandle(null, null, null, prev_job_id_maybe))
+            case _: AstJobId =>
+              /** AST construction jobs have no prerequisite tasks and thus always come with a task. */
+              Future.failed(new IllegalStateException(s"No task available for AST construction job $new_jid"))
           }
         case Some(task) =>
           /** What we really want here is SourceQueueWithComplete[Envelope]


### PR DESCRIPTION
## Summary
This PR adds JSON serialization support for several new message types in the Viper IDE protocol, improves code quality by treating compiler warnings as errors, and removes unused imports and code.

## Key Changes

- **New Message Type Serialization**: Added JSON writers for `BranchFailureMessage`, `BenchmarkingMessage`, `BlockReachedMessage`, `BlockFailureMessage`, and `PathProcessedMessage` in the ViperIDEProtocol
- **Enhanced Position Handling**: Added support for serializing `VirtualPosition` objects in the position JSON writer
- **Entry Type Support**: Added serialization for `UnspecifiedEntry` in the entry type JSON writer
- **Compiler Quality**: Enabled `-Xfatal-warnings` flag in build.sbt to treat all compiler warnings as errors, ensuring code quality in future changes
- **Unused Parameter Annotations**: Marked unused job pool parameters in `Terminator` class with `@unused` annotation to suppress warnings
- **Deprecation Handling**: Added `@nowarn` annotation to `documentSymbol` method in LSP Receiver to suppress deprecation warnings for required LSP4J interface
- **Type Safety**: Added `@unchecked` annotation in `JobActor.receive` to handle type erasure in pattern matching
- **Unused Import Cleanup**: Removed unused imports from multiple files (`DataProtocol.scala`, `Common.scala`, `ViperServerService.scala`, `MessageReportingTask.scala`)
- **Type Annotations**: Added explicit type annotations to improve code clarity (e.g., `logger: Logger`, `generateStuff: RootJsonFormat[AlloyGenerationRequest]`)
- **Error Handling**: Added proper error handling for AST construction jobs in `VerificationServer` with descriptive error message

## Notable Implementation Details

- The `CachedEntityMessage` handling includes a fallback case for custom backend implementations since the interface is not sealed
- Job pool parameters in `Terminator` are retained for future implementation of `WatchJobQueue` message handling
- All new message writers follow the existing pattern of using `lift` and `RootJsonWriter` for consistency with the protocol

https://claude.ai/code/session_01PGYyJTbqHfuizeew1LmVEJ