### PR TITLE
API for interrupting jobs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,12 @@ lazy val server = (project in file("."))
 
         // Test settings
         Test / parallelExecution := false,
+        // Silicon's symbolic execution requires deep stacks (hence `-Xss128m` for `run` above).
+        // The forked test JVM must provide the same stack size to every thread for which no
+        // explicit stack size is configured -- in particular to Silicon's worker pool threads --
+        // as tests would otherwise overflow on programs with long sequential statement chains
+        // (the platform-default thread stack is 1MB on Linux x64, e.g. in CI):
+        Test / javaOptions += "-Xss128m",
 
         // Assembly settings
         assembly / assemblyJarName := "viperserver.jar",                // JAR filename

--- a/src/main/scala/viper/server/core/VerificationWorker.scala
+++ b/src/main/scala/viper/server/core/VerificationWorker.scala
@@ -19,6 +19,7 @@ import viper.silver.utility.ViperProgramSubmitter
 import viper.silver.verifier.{AbstractVerificationError, VerificationResult, _}
 
 import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
 
 class ViperServerException extends Exception
 case class ViperServerWrongTypeException(name: String) extends ViperServerException {
@@ -123,8 +124,6 @@ class ViperBackend(val backendName: String, private val _frontend: SilFrontend, 
 
   /** Run the backend verification functionality */
   def execute(args: Seq[String]): Unit = {
-    initialize(args)
-
     /**
       * the architecture is as follows:
       * First, plugins can transform the AST (via their `beforeVerify` methods).
@@ -148,6 +147,10 @@ class ViperBackend(val backendName: String, private val _frontend: SilFrontend, 
       * verification errors that were expected but did not occur.
       */
     val overallResult = try {
+      // `initialize` starts the verifier and thereby its prover processes. It runs inside this
+      // `try` such that the provers are stopped even if a later initialization step fails or the
+      // job is cancelled (i.e. this thread is interrupted) during initialization:
+      initialize(args)
       val res = for {
         filteredProgram <- filter(_ast)
         innerProgram <- beforeVerify(filteredProgram)
@@ -340,8 +343,39 @@ class ViperBackend(val backendName: String, private val _frontend: SilFrontend, 
   /**
     * LA Jan 5 2023: unclear whether this is necessary at all. SilFrontend neither calls start nor stop on the verifier and ViperBackend used to call only stop in the past.
     */
+  /** stops the verifier and thereby destroys its prover processes.
+    *
+    * The teardown must complete even for a cancelled job: cancellation interrupts this thread (see
+    * `JobActor.interrupt`), and a still-pending interrupt would make the first blocking teardown
+    * step (e.g. `Process.waitFor` on a destroyed prover, or awaiting the termination of Silicon's
+    * verifier pool) throw `InterruptedException` and abandon the teardown half-way, leaking the
+    * remaining prover processes. Hence, the interrupt flag is cleared for the duration of the
+    * teardown and restored afterwards; an interrupt arriving during the teardown itself is handled
+    * by retrying it once (the individual teardown steps are idempotent).
+    */
   private def stop(): Unit = {
-    _frontend.verifier.stop()
+    var interruptPending = Thread.interrupted()
+    try {
+      // `initialize` might have failed before creating a verifier:
+      val verifier = _frontend.verifier
+      if (verifier != null) {
+        try {
+          verifier.stop()
+        } catch {
+          case _: InterruptedException =>
+            interruptPending = true
+            Thread.interrupted() // clear the flag again before retrying
+            verifier.stop()
+        }
+      }
+    } catch {
+      case NonFatal(e) =>
+        _frontend.logger.error("stopping the verification backend failed; prover processes might have been leaked", e)
+    } finally {
+      if (interruptPending) {
+        Thread.currentThread().interrupt()
+      }
+    }
   }
 
   private def finish(verificationResult: VerificationResult): Unit = {

--- a/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
+++ b/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
@@ -93,11 +93,10 @@ class ViperServerService(config: ViperConfig)(override implicit val executor: Ve
       case Some(handle_future) =>
         // the actual interrupt is delegated to `interruptVerification`. Note that the interrupted
         // job's task completes its message queue once it finished tearing down, which discards the
-        // job and stops its actors (see `initializeProcess`) -- the manual PoisonPill that used to
-        // live here is hence no longer necessary:
+        // job and stops its actors (see `initializeProcess`)
         val interrupted = interruptVerification(jid)
         // Free the ver slot so new jobs can be added immediately:
-        ver_jobs.discardJob(jid)
+        discardVerificationJobEagerly(jid)
         // Stop ast construction:
         handle_future.foreach(handle => handle.prev_job_id.foreach(astJobId => stopAstConstruction(astJobId, localLogger)))
         interrupted.map(verResult => {
@@ -113,12 +112,7 @@ class ViperServerService(config: ViperConfig)(override implicit val executor: Ve
 
   // Discards an AST job if it exists, the job will keep running but frees up a slot in the allowed number of jobs.
   def discardAstJobLookup(jid: AstJobId): Unit = {
-    ast_jobs.lookupJob(jid).map({job =>
-      ast_jobs.discardJob(jid)
-      job.map(astHandle => astHandle.queue.watchCompletion().onComplete(_ => {
-        astHandle.job_actor ! PoisonPill
-      }))
-    })
+    discardAstJobOnCompletion(jid)
   }
 
   def stopAstConstruction(jid: AstJobId, localLogger: Option[Logger] = None): Unit = {

--- a/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
+++ b/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
@@ -110,11 +110,6 @@ class ViperServerService(config: ViperConfig)(override implicit val executor: Ve
     }
   }
 
-  // Discards an AST job if it exists, the job will keep running but frees up a slot in the allowed number of jobs.
-  def discardAstJobLookup(jid: AstJobId): Unit = {
-    discardAstJobOnCompletion(jid)
-  }
-
   def stopAstConstruction(jid: AstJobId, localLogger: Option[Logger] = None): Unit = {
     stopOnlyAstConstruction(jid, localLogger).map { found =>
       if (found) discardAstJob(jid)

--- a/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
+++ b/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
@@ -6,22 +6,18 @@
 
 package viper.server.frontends.lsp
 
-import scala.language.postfixOps
 import akka.actor.{PoisonPill, Props}
-import akka.pattern.ask
-import akka.util.Timeout
 import ch.qos.logback.classic.Logger
 import viper.server.ViperConfig
 import viper.server.core.{VerificationExecutionContext, ViperBackendConfig, ViperCoreServer}
 import viper.server.utility.ReformatterAstGenerator
 import viper.server.utility.Helpers.validateViperFile
-import viper.server.vsi.VerificationProtocol.{StopAstConstruction, StopVerification}
-import viper.server.vsi.{AstJobId, DefaultVerificationServerStart, VerHandle, VerJobId}
+import viper.server.vsi.VerificationProtocol.StopAstConstruction
+import viper.server.vsi.{AstJobId, DefaultVerificationServerStart, VerJobId}
 import viper.silver.parser.ReformatPrettyPrinter
 import viper.silver.ast.utility.FileLoader
 
 import scala.concurrent.Future
-import scala.concurrent.duration._
 
 class ViperServerService(config: ViperConfig)(override implicit val executor: VerificationExecutionContext)
   extends ViperCoreServer(config)(executor) with DefaultVerificationServerStart {
@@ -95,37 +91,23 @@ class ViperServerService(config: ViperConfig)(override implicit val executor: Ve
     val logger = combineLoggers(localLogger)
     ver_jobs.lookupJob(jid) match {
       case Some(handle_future) =>
-        // Free the ver slot so new jobs can be added immediately
+        // the actual interrupt is delegated to `interruptVerification`. Note that the interrupted
+        // job's task completes its message queue once it finished tearing down, which discards the
+        // job and stops its actors (see `initializeProcess`) -- the manual PoisonPill that used to
+        // live here is hence no longer necessary:
+        val interrupted = interruptVerification(jid)
+        // Free the ver slot so new jobs can be added immediately:
         ver_jobs.discardJob(jid)
-        handle_future.flatMap(handle => {
-          // Stop ast construction
-          handle.prev_job_id.foreach(astJobId => stopAstConstruction(astJobId, localLogger))
-          stopOnlyVerification(handle, logger)
-            .map(verResult => {
-              logger.info(s"verification stopped for job #$jid")
-              verResult
-            })
+        // Stop ast construction:
+        handle_future.foreach(handle => handle.prev_job_id.foreach(astJobId => stopAstConstruction(astJobId, localLogger)))
+        interrupted.map(verResult => {
+          logger.info(s"verification stopped for job #$jid")
+          verResult
         })
       case _ =>
         // Did not find a job with this jid.
         logger.warn(s"stopVerification - The verification job #$jid does not exist and can thus not be stopped.")
         Future.successful(false)
-    }
-  }
-
-  private def stopOnlyVerification(handle: VerHandle, combinedLogger: Logger): Future[Boolean] = {
-    handle match {
-      // If AST construction failed, a verification handle will be returned where the actor field is null.
-      case VerHandle(null, _, _, _) => Future.successful(false)
-      case _ => {
-        implicit val askTimeout: Timeout = Timeout(config.actorCommunicationTimeout() milliseconds)
-        val interrupt: Future[String] = (handle.job_actor ? StopVerification).mapTo[String]
-        handle.job_actor ! PoisonPill // the actor played its part.
-        interrupt.map(msg => {
-          combinedLogger.info(msg)
-          true
-        })
-      }
     }
   }
 

--- a/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
+++ b/src/main/scala/viper/server/frontends/lsp/ViperServerService.scala
@@ -6,7 +6,7 @@
 
 package viper.server.frontends.lsp
 
-import akka.actor.{PoisonPill, Props}
+import akka.actor.Props
 import ch.qos.logback.classic.Logger
 import viper.server.ViperConfig
 import viper.server.core.{VerificationExecutionContext, ViperBackendConfig, ViperCoreServer}
@@ -122,7 +122,7 @@ class ViperServerService(config: ViperConfig)(override implicit val executor: Ve
       case Some(handle_future) =>
         handle_future.map { handle =>
           handle.job_actor ! StopAstConstruction
-          handle.job_actor ! PoisonPill // the actor played its part.
+          // the job's actor is stopped as soon as the job's message queue completes (see `initializeProcess`)
           combinedLogger.info(s"ast construction stopped for job #$jid")
           true
         }

--- a/src/main/scala/viper/server/frontends/lsp/file/Verification.scala
+++ b/src/main/scala/viper/server/frontends/lsp/file/Verification.scala
@@ -48,7 +48,7 @@ case class VerificationHandler(server: lsp.ViperServerService, logger: Logger) {
     waitingOn match {
       case Some(Left(jid)) =>
         logger.warn(s"Discarding uncompleted AST job $jid (though it will keep running), only keeping handle to verification job.")
-        server.discardAstJobOnCompletion(jid)
+        server.discardAstJob(jid)
       case _ =>
     }
     waitingOn = Some(Right(ver))
@@ -248,7 +248,7 @@ trait VerificationManager extends ManagesLeaf {
         true
       } else {
         // Ver pool full — free the orphaned AST slot
-        coordinator.server.discardAstJobOnCompletion(astJob)
+        coordinator.server.discardAstJob(astJob)
         false
       }
     })

--- a/src/main/scala/viper/server/frontends/lsp/file/Verification.scala
+++ b/src/main/scala/viper/server/frontends/lsp/file/Verification.scala
@@ -48,7 +48,7 @@ case class VerificationHandler(server: lsp.ViperServerService, logger: Logger) {
     waitingOn match {
       case Some(Left(jid)) =>
         logger.warn(s"Discarding uncompleted AST job $jid (though it will keep running), only keeping handle to verification job.")
-        server.discardAstJobLookup(jid)
+        server.discardAstJobOnCompletion(jid)
       case _ =>
     }
     waitingOn = Some(Right(ver))
@@ -248,7 +248,7 @@ trait VerificationManager extends ManagesLeaf {
         true
       } else {
         // Ver pool full — free the orphaned AST slot
-        coordinator.server.discardAstJobLookup(astJob)
+        coordinator.server.discardAstJobOnCompletion(astJob)
         false
       }
     })

--- a/src/main/scala/viper/server/vsi/HTTP.scala
+++ b/src/main/scala/viper/server/vsi/HTTP.scala
@@ -223,7 +223,8 @@ trait VerificationServerHttp extends VerificationServer with CustomizableHttp {
           onComplete(handle_future) {
             case Success(handle) =>
               implicit val askTimeout: Timeout = Timeout(5000 milliseconds)
-              val interrupt_done: Future[String] = (handle.job_actor ? StopVerification).mapTo[String]
+              val interrupt_done: Future[String] =
+                (handle.job_actor ? StopVerification).mapTo[VerificationProtocol.StopProcessReply].map(_.message)
               onSuccess(interrupt_done) { msg =>
                 handle.job_actor ! PoisonPill // the actor played its part.
                 complete(discardJobConfirmation(id, msg))

--- a/src/main/scala/viper/server/vsi/HTTP.scala
+++ b/src/main/scala/viper/server/vsi/HTTP.scala
@@ -227,7 +227,7 @@ trait VerificationServerHttp extends VerificationServer with CustomizableHttp {
                 (handle.job_actor ? StopVerification).mapTo[VerificationProtocol.StopProcessReply].map(_.message)
               onSuccess(interrupt_done) { msg =>
                 // note that the job's actor is stopped as soon as the job's message queue
-                // completes (see `initializeProcess`), i.e. it must not be stopped here:
+                // completes (see `initializeProcess`)
                 complete(discardJobConfirmation(id, msg))
               }
             case Failure(_) =>

--- a/src/main/scala/viper/server/vsi/HTTP.scala
+++ b/src/main/scala/viper/server/vsi/HTTP.scala
@@ -7,7 +7,7 @@
 package viper.server.vsi
 
 import akka.{Done, NotUsed}
-import akka.actor.PoisonPill
+
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
@@ -226,7 +226,8 @@ trait VerificationServerHttp extends VerificationServer with CustomizableHttp {
               val interrupt_done: Future[String] =
                 (handle.job_actor ? StopVerification).mapTo[VerificationProtocol.StopProcessReply].map(_.message)
               onSuccess(interrupt_done) { msg =>
-                handle.job_actor ! PoisonPill // the actor played its part.
+                // note that the job's actor is stopped as soon as the job's message queue
+                // completes (see `initializeProcess`), i.e. it must not be stopped here:
                 complete(discardJobConfirmation(id, msg))
               }
             case Failure(_) =>

--- a/src/main/scala/viper/server/vsi/JobActor.scala
+++ b/src/main/scala/viper/server/vsi/JobActor.scala
@@ -6,8 +6,6 @@
 
 package viper.server.vsi
 
-import java.util.concurrent.FutureTask
-
 import akka.actor.{Actor, Props}
 
 
@@ -15,37 +13,66 @@ import akka.actor.{Actor, Props}
 
 object JobActor {
   def props[T](id: JobId): Props = Props(new JobActor[T](id))
+
+  private def interruptedReply(id: JobId): String = s"$id has been successfully interrupted."
+  private def finalizedReply(id: JobId): String = s"$id has already been finalized."
+
+  /** whether a reply to a [[VerificationProtocol.StopProcessRequest]] indicates that an active
+    * task has been interrupted (as opposed to there being nothing left to interrupt) */
+  def indicatesInterrupted(reply: String): Boolean = reply.endsWith("interrupted.")
 }
 
 class JobActor[T](private val id: JobId) extends Actor {
 
   import VerificationProtocol._
 
-  private var _astConstructionTask: FutureTask[T] = _
-  private var _verificationTask: FutureTask[T] = _
+  private var _astConstructionRequest: StartProcessRequest[T] = _
+  private var _verificationRequest: StartProcessRequest[T] = _
 
-  private def interrupt(task: FutureTask[T]): Boolean = {
-    if (task != null && !task.isDone) {
-      task.cancel(true)
+  private def interrupt(req: StartProcessRequest[T]): Boolean = {
+    if (req != null && !req.task.futureTask.isDone) {
+      req.task.futureTask.cancel(true)
+      completeQueueIfTaskNeverRan(req)
       return true
     }
     false
   }
 
-  private def resetTask(task: FutureTask[T]): Unit = {
-    if (task != null && !task.isDone) {
-      task.cancel(true)
+  private def resetTask(req: StartProcessRequest[T]): Unit = {
+    if (req != null && !req.task.futureTask.isDone) {
+      req.task.futureTask.cancel(true)
+      completeQueueIfTaskNeverRan(req)
+    }
+  }
+
+  /** The message queue is normally completed by the running task (via `registerTaskEnd`). A task
+    * that is cancelled before it ever started will never do so, which would leave the queue --
+    * and thereby the job's message stream and its completion-triggered cleanup -- pending forever.
+    * Complete the queue on the task's behalf in that case; `cancelledBeforeStart` guarantees that
+    * the task can no longer start, i.e. that nobody else will complete the queue.
+    */
+  private def completeQueueIfTaskNeverRan(req: StartProcessRequest[T]): Unit = {
+    if (req.task.cancelledBeforeStart) {
+      // completing via the queue actor (mirroring `registerTaskEnd`) also stops that actor;
+      // completing the queue directly would leak it. The queue actor is unset only for tasks
+      // constructed outside `initializeProcess` (e.g. in unit tests):
+      val queueActor = req.task.queueActor
+      if (queueActor != null) {
+        queueActor ! TaskProtocol.FinalBackendReport(success = false)
+      } else {
+        req.queue.complete()
+      }
     }
   }
 
   private def resetAstConstructionTask(): Unit = {
-    resetTask(_astConstructionTask)
-    _astConstructionTask = null
+    resetTask(_astConstructionRequest)
+    _astConstructionRequest = null
   }
 
   private def resetVerificationTask(): Unit = {
-    resetTask(_verificationTask)
-    _verificationTask = null
+    resetTask(_verificationRequest)
+    _verificationRequest = null
   }
 
   override def receive: PartialFunction[Any, Unit] = {
@@ -56,29 +83,29 @@ class JobActor[T](private val id: JobId) extends Actor {
         case _: ConstructAst[T] =>
           //println(">>> JobActor received request ConstructAst")
           resetAstConstructionTask()
-          _astConstructionTask = req.task.futureTask
-          req.executor.execute(_astConstructionTask)
+          _astConstructionRequest = req
+          req.executor.execute(req.task.futureTask)
           sender() ! AstHandle(self, req.queue, req.publisher, req.task.artifact)
 
         case ver_req: Verify[T] =>
           //println(">>> JobActor received request Verify")
           resetVerificationTask()
-          _verificationTask = ver_req.task.futureTask
-          req.executor.execute(_verificationTask)
+          _verificationRequest = ver_req
+          req.executor.execute(ver_req.task.futureTask)
           sender() ! VerHandle(self, ver_req.queue, ver_req.publisher, ver_req.prev_job_id)
       }
     case req: StopProcessRequest =>
       val did_I_interrupt = req match {
         case StopAstConstruction =>
-          interrupt(_astConstructionTask)
+          interrupt(_astConstructionRequest)
         case StopVerification =>
-          interrupt(_verificationTask)
+          interrupt(_verificationRequest)
       }
       if (did_I_interrupt) {
-        sender() ! s"$id has been successfully interrupted."
+        sender() ! JobActor.interruptedReply(id)
       } else {
         // FIXME: Saying this is a potential vulnerability
-        sender() ! s"$id has already been finalized."
+        sender() ! JobActor.finalizedReply(id)
       }
     case msg =>
       throw new Exception("JobActor: received unexpected message: " + msg)

--- a/src/main/scala/viper/server/vsi/JobActor.scala
+++ b/src/main/scala/viper/server/vsi/JobActor.scala
@@ -13,13 +13,6 @@ import akka.actor.{Actor, Props}
 
 object JobActor {
   def props[T](id: JobId): Props = Props(new JobActor[T](id))
-
-  private def interruptedReply(id: JobId): String = s"$id has been successfully interrupted."
-  private def finalizedReply(id: JobId): String = s"$id has already been finalized."
-
-  /** whether a reply to a [[VerificationProtocol.StopProcessRequest]] indicates that an active
-    * task has been interrupted (as opposed to there being nothing left to interrupt) */
-  def indicatesInterrupted(reply: String): Boolean = reply.endsWith("interrupted.")
 }
 
 class JobActor[T](private val id: JobId) extends Actor {
@@ -102,10 +95,10 @@ class JobActor[T](private val id: JobId) extends Actor {
           interrupt(_verificationRequest)
       }
       if (did_I_interrupt) {
-        sender() ! JobActor.interruptedReply(id)
+        sender() ! StopProcessReply(interrupted = true, s"$id has been successfully interrupted.")
       } else {
         // FIXME: Saying this is a potential vulnerability
-        sender() ! JobActor.finalizedReply(id)
+        sender() ! StopProcessReply(interrupted = false, s"$id has already been finalized.")
       }
     case msg =>
       throw new Exception("JobActor: received unexpected message: " + msg)

--- a/src/main/scala/viper/server/vsi/JobPool.scala
+++ b/src/main/scala/viper/server/vsi/JobPool.scala
@@ -83,7 +83,14 @@ class JobPool[S <: JobId, T <: JobHandle](val tag: String, val MAX_ACTIVE_JOBS: 
     new_jid
   }
 
-  def discardJob(jid: S): Unit = {
+  /** Removes the job from this pool, freeing its slot. This is deliberately not accessible
+    * outside the vsi layer: discarding at the wrong moment violates the job lifecycle's
+    * invariants (e.g. a job discarded before its message stream is attached can never be
+    * streamed, and an eagerly freed slot lets a new job's resources race the old job's
+    * teardown). Frontends express such policies through `VerificationServer`'s dedicated
+    * methods instead.
+    */
+  private[vsi] def discardJob(jid: S): Unit = {
     _jobHandles -= jid
     _jobExecutors -= jid
     _jobCache -= jid

--- a/src/main/scala/viper/server/vsi/JobPool.scala
+++ b/src/main/scala/viper/server/vsi/JobPool.scala
@@ -86,8 +86,8 @@ class JobPool[S <: JobId, T <: JobHandle](val tag: String, val MAX_ACTIVE_JOBS: 
   /** Removes the job from this pool, freeing its slot. This is deliberately not accessible
     * outside the vsi layer: discarding at the wrong moment violates the job lifecycle's
     * invariants (e.g. a job discarded before its message stream is attached can never be
-    * streamed, and an eagerly freed slot lets a new job's resources race the old job's
-    * teardown). Frontends express such policies through `VerificationServer`'s dedicated
+    * streamed, and an eagerly freed slot admits a new job that will contend with the old job
+    * about resources). Frontends express such policies through `VerificationServer`'s dedicated
     * methods instead.
     */
   private[vsi] def discardJob(jid: S): Unit = {

--- a/src/main/scala/viper/server/vsi/MessageStreamingTask.scala
+++ b/src/main/scala/viper/server/vsi/MessageStreamingTask.scala
@@ -6,7 +6,7 @@
 
 package viper.server.vsi
 
-import java.util.concurrent.{Callable, FutureTask}
+import java.util.concurrent.{Callable, CancellationException, FutureTask}
 import scala.language.postfixOps
 import akka.actor.ActorRef
 import akka.pattern.ask
@@ -34,8 +34,35 @@ abstract class MessageStreamingTask[T] extends Callable[T] with Post {
 
   private lazy val artifactPromise = Promise[T]()
   lazy val artifact: Future[T] = artifactPromise.future
-  lazy val futureTask: FutureTask[T] = new FutureTask(this) {
+
+  /** guards `callableStarted` and thereby synchronizes starting the task against `cancelledBeforeStart` */
+  private val startSync = new Object
+  private var callableStarted: Boolean = false // guarded by `startSync`
+
+  lazy val futureTask: FutureTask[T] = new FutureTask[T](() => {
+    startSync.synchronized {
+      // a `FutureTask` remains in its initial state while the callable is executing, i.e. a
+      // successful `cancel` alone cannot tell a task that will never run apart from a task that is
+      // running right now. This handshake makes that distinction: `cancelledBeforeStart` observing
+      // a cancelled task without `callableStarted` under this lock guarantees that this check has
+      // not run yet and will fail once it does, i.e. that `call()` will never be invoked.
+      if (futureTask.isCancelled) {
+        throw new CancellationException()
+      }
+      callableStarted = true
+    }
+    call()
+  }) {
     override def done(): Unit = artifactPromise.complete(Try(get()))
+  }
+
+  /** Returns true iff this task has been cancelled without its callable ever starting. A positive
+    * answer is stable: the callable is then guaranteed to never run. Callers may hence take over
+    * the cancelled task's cleanup duties that the callable would otherwise have performed, such as
+    * completing the task's message queue (see `JobActor`).
+    */
+  final def cancelledBeforeStart: Boolean = startSync.synchronized {
+    futureTask.isCancelled && !callableStarted
   }
 
   private var q_actor: ActorRef = _
@@ -48,6 +75,9 @@ abstract class MessageStreamingTask[T] extends Callable[T] with Post {
 
     q_actor = actor
   }
+
+  /** the actor managing this task's message queue; null until `setQueueActor` has been called */
+  private[vsi] def queueActor: ActorRef = q_actor
 
   /** Sends massage to the attached actor.
     *

--- a/src/main/scala/viper/server/vsi/Protocol.scala
+++ b/src/main/scala/viper/server/vsi/Protocol.scala
@@ -46,6 +46,14 @@ object VerificationProtocol {
 
   // Request Job Actor to stop its verification task
   case object StopVerification extends StopProcessRequest
+
+  /** the JobActor's reply to a [[StopProcessRequest]]
+    *
+    * @param interrupted whether an active task has been interrupted; false if there was nothing
+    *                    left to interrupt, i.e. the task already completed or none was submitted
+    * @param message human-readable description of the outcome
+    */
+  case class StopProcessReply(interrupted: Boolean, message: String)
 }
 
 

--- a/src/main/scala/viper/server/vsi/VerificationServer.scala
+++ b/src/main/scala/viper/server/vsi/VerificationServer.scala
@@ -128,8 +128,10 @@ trait VerificationServer extends Post {
             if (discardOnCompletion) {
                 pool.discardJob(new_jid)
             }
-            /** FIXME: if the job actors are meant to be reused from one phase to another (only partially implemented),
-              * FIXME: then they should be stopped only after the **last** job is completed in the pipeline. */
+            // we make sure that the job actor is killed, without leaving this up to clients that might forget
+            // about doing so and, thus, leak job actors.
+            /** FIXME: we don't support reusing job actors across phases. Implementing this feature would
+              * require killing the job actor only after the **last** job is completed in the pipeline. */
             job_actor ! PoisonPill
           })
 
@@ -185,10 +187,7 @@ trait VerificationServer extends Post {
 
   /** Discards the AST job identified by `jid`, freeing its slot while the job keeps running.
     * Since AST jobs, unlike verification jobs, do not free their slot when their message queue
-    * completes -- their artifact may still be consumed by later verifications -- their lifetime
-    * is managed by the frontend via this function. The job's actor requires no attention here:
-    * every job's actor is stopped once the job's message queue completes (see
-    * `initializeProcess`).
+    * completes, frontends must, thus, manage their lifetime by calling this function.
     */
   def discardAstJob(jid: AstJobId): Unit = {
     ast_jobs.discardJob(jid)
@@ -198,6 +197,8 @@ trait VerificationServer extends Post {
     * the job to finish or tear down nor interrupting the job.
     * Note that new jobs will be admitted to the freed slot, which will contend with this
     * verification job.
+    * Calling this function by frontends is however optional as verification jobs automatically
+    * free their slot when their message queue completes.
     */
   protected def discardVerificationJobEagerly(jid: VerJobId): Unit = {
     ver_jobs.discardJob(jid)

--- a/src/main/scala/viper/server/vsi/VerificationServer.scala
+++ b/src/main/scala/viper/server/vsi/VerificationServer.scala
@@ -14,10 +14,12 @@ import akka.stream.OverflowStrategy
 import akka.util.Timeout
 import viper.server.core.VerificationExecutionContext
 
+import java.util.concurrent.CancellationException
 import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
+import scala.util.control.NonFatal
 import scala.language.postfixOps
 
 
@@ -153,6 +155,14 @@ trait VerificationServer extends Post {
         val msg = s"AST construction job ${prev_job_id_maybe.get} resulted in a failure: $e"
         println(msg)
         pool.discardJob(new_jid)
+      case e: CancellationException =>
+        // The AST construction task this job depends on has been cancelled (e.g. via
+        // `interruptAstConstruction`), which fails its artifact future with a
+        // CancellationException. The dependent job must be removed from the pool as well --
+        // otherwise its slot would leak forever (no task ever runs for it, i.e. its queue is
+        // never completed and the completion-triggered cleanup never fires):
+        println(s"AST construction job ${prev_job_id_maybe.get} has been cancelled: $e")
+        pool.discardJob(new_jid)
     }).mapTo[T])
   }
 
@@ -272,6 +282,77 @@ trait VerificationServer extends Post {
         }
       }
     })
+  }
+
+  /** Requests the AST construction identified by `jid` to stop, analogously to
+    * `interruptVerification` (which documents the detailed contract). A verification job waiting
+    * for this AST construction job observes the cancellation as a failed AST artifact and is
+    * discarded from the job pool (see `initializeProcess`). Note that, unlike verification jobs,
+    * AST construction jobs are not discarded when their queue completes; interrupting one does
+    * not change how it is cleaned up (see `discardAstJob`).
+    */
+  def interruptAstConstruction(jid: AstJobId): Future[Boolean] = {
+    interruptJob(ast_jobs, jid, VerificationProtocol.StopAstConstruction)
+  }
+
+  /** Requests the verification identified by `jid` to stop, without waiting for its teardown: a
+    * running verification task is interrupted, and a task that has not started yet is prevented
+    * from ever starting.
+    *
+    * The returned future completes once the job's actor has acknowledged the interrupt (bounded
+    * by `askTimeout`), which is NOT when the verification's teardown has finished: an interrupted
+    * task cleans up asynchronously (e.g. stopping backend processes) before it completes its
+    * message queue. Consumers observe the end of the teardown through the job's message stream
+    * (see `streamMessages`), which completes only once the interrupted task is done cleaning up.
+    * The job is discarded from the job pool at that point (see `initializeProcess`); this method
+    * deliberately does not discard the job early, so that a new job's resources cannot race with
+    * the interrupted job's teardown.
+    *
+    * Returns true iff an active verification task has been interrupted. In particular, false is
+    * returned if the job id is unknown (e.g. because the job already finished and has been
+    * cleaned up), the job's task already completed, or this server is not running. Note that a
+    * verification job that waits for a separate AST construction job (see
+    * `initializeVerificationProcess`) has no verification task to interrupt yet -- this method
+    * then returns false and callers should interrupt the AST construction job, which they know
+    * by id, instead (see `interruptAstConstruction`).
+    */
+  def interruptVerification(jid: VerJobId): Future[Boolean] = {
+    interruptJob(ver_jobs, jid, VerificationProtocol.StopVerification)
+  }
+
+  /** Asks `jid`'s job actor to interrupt its task; false if there is no such active job, the ask
+    * is not answered, or the job's handle does not resolve in time.
+    *
+    * All future callbacks are deliberately scheduled on the actor system's dispatcher instead of
+    * on `executor`: the latter is the pool that executes the tasks themselves, i.e. exactly the
+    * pool that is saturated in the situation this method exists for -- callbacks scheduled there
+    * would wait in line behind the very tasks they are meant to interrupt. The actor system's
+    * dispatcher is the right liveness domain because the ask cannot be processed without it
+    * either. The overall wait is bounded by `askTimeout` because a job's handle future can take
+    * arbitrarily long to resolve (a verification job's handle only resolves once its prerequisite
+    * AST construction finished, see `initializeProcess`).
+    */
+  private def interruptJob[S <: JobId, T <: JobHandle](pool: JobPool[S, T], jid: S, msg: VerificationProtocol.StopProcessRequest): Future[Boolean] = {
+    val dispatcher = system.dispatcher
+    if (!isRunning) {
+      return Future.successful(false)
+    }
+    pool.lookupJob(jid) match {
+      case Some(handle_future) =>
+        val interruptFuture = handle_future.flatMap(handle =>
+          if (handle.job_actor == null) {
+            /** the job failed before a task was submitted */
+            Future.successful(false)
+          } else {
+            (handle.job_actor ? msg).mapTo[String]
+              .map(JobActor.indicatesInterrupted)(dispatcher)
+          }
+        )(dispatcher).recover { case NonFatal(_) => false }(dispatcher)
+        val timeoutFuture = akka.pattern.after(askTimeout.duration, system.scheduler)(Future.successful(false))(dispatcher)
+        Future.firstCompletedOf(Seq(interruptFuture, timeoutFuture))(dispatcher)
+      case None =>
+        Future.successful(false)
+    }
   }
 
   /** Stops an instance of VerificationServer from running.

--- a/src/main/scala/viper/server/vsi/VerificationServer.scala
+++ b/src/main/scala/viper/server/vsi/VerificationServer.scala
@@ -182,6 +182,31 @@ trait VerificationServer extends Post {
     ast_jobs.discardJob(jid)
   }
 
+  /** Discards the AST job identified by `jid` (if it exists), freeing its slot while the job
+    * keeps running, and stops the job's actor once the job's message queue has completed. This
+    * exists because AST jobs, unlike verification jobs, have no completion-triggered cleanup
+    * (see `initializeProcess`).
+    */
+  protected def discardAstJobOnCompletion(jid: AstJobId): Unit = {
+    ast_jobs.lookupJob(jid).foreach(handle_future => {
+      ast_jobs.discardJob(jid)
+      handle_future.foreach(astHandle => astHandle.queue.watchCompletion().onComplete(_ => {
+        astHandle.job_actor ! PoisonPill
+      }))
+    })
+  }
+
+  /** Frees the slot of the verification job identified by `jid` immediately, without waiting for
+    * the job to finish or tear down. This is a frontend policy decision with a documented cost:
+    * a new job admitted into the freed slot runs concurrently with the old job's remaining work
+    * or teardown (e.g. its backend processes). Callers that can afford to wait should instead
+    * rely on the completion-triggered cleanup (see `initializeProcess` and
+    * `interruptVerification`), which frees the slot exactly when the job's teardown has finished.
+    */
+  protected def discardVerificationJobEagerly(jid: VerJobId): Unit = {
+    ver_jobs.discardJob(jid)
+  }
+
   /** This method starts a verification process.
     *
     * As such, it accepts an instance of a VerificationTask, which it will pass to the JobActor.
@@ -344,8 +369,8 @@ trait VerificationServer extends Post {
             /** the job failed before a task was submitted */
             Future.successful(false)
           } else {
-            (handle.job_actor ? msg).mapTo[String]
-              .map(JobActor.indicatesInterrupted)(dispatcher)
+            (handle.job_actor ? msg).mapTo[VerificationProtocol.StopProcessReply]
+              .map(_.interrupted)(dispatcher)
           }
         )(dispatcher).recover { case NonFatal(_) => false }(dispatcher)
         val timeoutFuture = akka.pattern.after(askTimeout.duration, system.scheduler)(Future.successful(false))(dispatcher)
@@ -387,11 +412,11 @@ trait VerificationServer extends Post {
       case (_, handle_future) =>
         handle_future.flatMap {
           case AstHandle(actor, _, _, _) =>
-            (actor ? VerificationProtocol.StopAstConstruction).mapTo[String]
+            (actor ? VerificationProtocol.StopAstConstruction).mapTo[VerificationProtocol.StopProcessReply].map(_.message)
           case VerHandle(null, _, _, _) =>
             Future.successful("Job had no actor.")
           case VerHandle(actor, _, _, _) =>
-            (actor ? VerificationProtocol.StopVerification).mapTo[String]
+            (actor ? VerificationProtocol.StopVerification).mapTo[VerificationProtocol.StopProcessReply].map(_.message)
         }.recover {
           case _: akka.pattern.AskTimeoutException =>
             "Job actor already terminated."

--- a/src/main/scala/viper/server/vsi/VerificationServer.scala
+++ b/src/main/scala/viper/server/vsi/VerificationServer.scala
@@ -185,9 +185,10 @@ trait VerificationServer extends Post {
   /** Discards the AST job identified by `jid` (if it exists), freeing its slot while the job
     * keeps running, and stops the job's actor once the job's message queue has completed. This
     * exists because AST jobs, unlike verification jobs, have no completion-triggered cleanup
-    * (see `initializeProcess`).
+    * (see `initializeProcess`): their lifetime is managed by the frontend, which is why this
+    * method is public.
     */
-  protected def discardAstJobOnCompletion(jid: AstJobId): Unit = {
+  def discardAstJobOnCompletion(jid: AstJobId): Unit = {
     ast_jobs.lookupJob(jid).foreach(handle_future => {
       ast_jobs.discardJob(jid)
       handle_future.foreach(astHandle => astHandle.queue.watchCompletion().onComplete(_ => {

--- a/src/main/scala/viper/server/vsi/VerificationServer.scala
+++ b/src/main/scala/viper/server/vsi/VerificationServer.scala
@@ -118,14 +118,19 @@ trait VerificationServer extends Post {
 
           val job_actor = system.actorOf(JobActor.props(new_jid), s"${pool.tag}_job_actor_${new_jid}")
 
-          /** Register cleanup task. */
+          /** Register cleanup task: the job's actor has played its part once the job's message
+            * queue has completed. Whether the job's slot is freed at that point as well is a
+            * per-job-kind policy (`discardOnCompletion`): verification jobs are cleaned up
+            * automatically, whereas AST jobs remain in the pool -- their artifact may still be
+            * consumed by later verifications, i.e. their lifetime is managed by the frontend
+            * (see `discardAstJob`). */
           queue.watchCompletion().onComplete(_ => {
             if (discardOnCompletion) {
                 pool.discardJob(new_jid)
-                /** FIXME: if the job actors are meant to be reused from one phase to another (only partially implemented),
-                  * FIXME: then they should be stopped only after the **last** job is completed in the pipeline. */
-                job_actor ! PoisonPill
             }
+            /** FIXME: if the job actors are meant to be reused from one phase to another (only partially implemented),
+              * FIXME: then they should be stopped only after the **last** job is completed in the pipeline. */
+            job_actor ! PoisonPill
           })
 
           (job_actor ? (new_jid match {
@@ -178,31 +183,21 @@ trait VerificationServer extends Post {
     }
   }
 
-  protected def discardAstJob(jid: AstJobId): Unit = {
+  /** Discards the AST job identified by `jid`, freeing its slot while the job keeps running.
+    * Since AST jobs, unlike verification jobs, do not free their slot when their message queue
+    * completes -- their artifact may still be consumed by later verifications -- their lifetime
+    * is managed by the frontend via this function. The job's actor requires no attention here:
+    * every job's actor is stopped once the job's message queue completes (see
+    * `initializeProcess`).
+    */
+  def discardAstJob(jid: AstJobId): Unit = {
     ast_jobs.discardJob(jid)
   }
 
-  /** Discards the AST job identified by `jid` (if it exists), freeing its slot while the job
-    * keeps running, and stops the job's actor once the job's message queue has completed. This
-    * exists because AST jobs, unlike verification jobs, have no completion-triggered cleanup
-    * (see `initializeProcess`): their lifetime is managed by the frontend, which is why this
-    * method is public.
-    */
-  def discardAstJobOnCompletion(jid: AstJobId): Unit = {
-    ast_jobs.lookupJob(jid).foreach(handle_future => {
-      ast_jobs.discardJob(jid)
-      handle_future.foreach(astHandle => astHandle.queue.watchCompletion().onComplete(_ => {
-        astHandle.job_actor ! PoisonPill
-      }))
-    })
-  }
-
-  /** Frees the slot of the verification job identified by `jid` immediately, without waiting for
-    * the job to finish or tear down. This is a frontend policy decision with a documented cost:
-    * a new job admitted into the freed slot runs concurrently with the old job's remaining work
-    * or teardown (e.g. its backend processes). Callers that can afford to wait should instead
-    * rely on the completion-triggered cleanup (see `initializeProcess` and
-    * `interruptVerification`), which frees the slot exactly when the job's teardown has finished.
+  /** Frees the slot of the verification job identified by `jid` immediately, neither waiting for
+    * the job to finish or tear down nor interrupting the job.
+    * Note that new jobs will be admitted to the freed slot, which will contend with this
+    * verification job.
     */
   protected def discardVerificationJobEagerly(jid: VerJobId): Unit = {
     ver_jobs.discardJob(jid)

--- a/src/test/resources/viper/long_running.vpr
+++ b/src/test/resources/viper/long_running.vpr
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2026 ETH Zurich.
+
+// This program's verification is reliably long-running: Silicon explores both branches of every
+// `if` separately, i.e. the method below has 2^30 symbolic execution paths. Verifying it hence
+// takes practically forever -- independently of any SMT solver behavior -- which makes it
+// suitable for testing that a running verification can be interrupted.
+method slow(b0: Bool, b1: Bool, b2: Bool, b3: Bool, b4: Bool, b5: Bool, b6: Bool, b7: Bool, b8: Bool, b9: Bool, b10: Bool, b11: Bool, b12: Bool, b13: Bool, b14: Bool, b15: Bool, b16: Bool, b17: Bool, b18: Bool, b19: Bool, b20: Bool, b21: Bool, b22: Bool, b23: Bool, b24: Bool, b25: Bool, b26: Bool, b27: Bool, b28: Bool, b29: Bool)
+{
+  var x: Int := 0
+  if (b0) { x := x + 1 } else { x := x - 1 }
+  if (b1) { x := x + 1 } else { x := x - 1 }
+  if (b2) { x := x + 1 } else { x := x - 1 }
+  if (b3) { x := x + 1 } else { x := x - 1 }
+  if (b4) { x := x + 1 } else { x := x - 1 }
+  if (b5) { x := x + 1 } else { x := x - 1 }
+  if (b6) { x := x + 1 } else { x := x - 1 }
+  if (b7) { x := x + 1 } else { x := x - 1 }
+  if (b8) { x := x + 1 } else { x := x - 1 }
+  if (b9) { x := x + 1 } else { x := x - 1 }
+  if (b10) { x := x + 1 } else { x := x - 1 }
+  if (b11) { x := x + 1 } else { x := x - 1 }
+  if (b12) { x := x + 1 } else { x := x - 1 }
+  if (b13) { x := x + 1 } else { x := x - 1 }
+  if (b14) { x := x + 1 } else { x := x - 1 }
+  if (b15) { x := x + 1 } else { x := x - 1 }
+  if (b16) { x := x + 1 } else { x := x - 1 }
+  if (b17) { x := x + 1 } else { x := x - 1 }
+  if (b18) { x := x + 1 } else { x := x - 1 }
+  if (b19) { x := x + 1 } else { x := x - 1 }
+  if (b20) { x := x + 1 } else { x := x - 1 }
+  if (b21) { x := x + 1 } else { x := x - 1 }
+  if (b22) { x := x + 1 } else { x := x - 1 }
+  if (b23) { x := x + 1 } else { x := x - 1 }
+  if (b24) { x := x + 1 } else { x := x - 1 }
+  if (b25) { x := x + 1 } else { x := x - 1 }
+  if (b26) { x := x + 1 } else { x := x - 1 }
+  if (b27) { x := x + 1 } else { x := x - 1 }
+  if (b28) { x := x + 1 } else { x := x - 1 }
+  if (b29) { x := x + 1 } else { x := x - 1 }
+  assert -30 <= x && x <= 30
+}

--- a/src/test/resources/viper/long_running.vpr
+++ b/src/test/resources/viper/long_running.vpr
@@ -1,8 +1,5 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-//
-// Copyright (c) 2011-2026 ETH Zurich.
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
 
 // This program's verification is reliably long-running: Silicon explores both branches of every
 // `if` separately, i.e. the method below has 2^30 symbolic execution paths. Verifying it hence

--- a/src/test/scala/viper/server/core/CoreServerSpec.scala
+++ b/src/test/scala/viper/server/core/CoreServerSpec.scala
@@ -54,6 +54,7 @@ class CoreServerSpec extends AnyWordSpec with Matchers {
   private val empty_viper_file = "src/test/resources/viper/empty.vpr"
   private val correct_viper_file = "src/test/resources/viper/sum_method.vpr"
   private val ver_error_file = "src/test/resources/viper/verification_error.vpr"
+  private val long_running_file = "src/test/resources/viper/long_running.vpr"
   private val execution_context_terminate_timeout_ms = 1000 // 1 sec
 
   private val files = List(empty_viper_file, correct_viper_file, ver_error_file)
@@ -178,6 +179,59 @@ class CoreServerSpec extends AnyWordSpec with Matchers {
       Future.successful(assertThrows[IllegalStateException] {
         verifySiliconWithoutCaching(core, ver_error_file)
       })
+    })
+
+    s"be able to interrupt a verification while it is running" in withServer[ViperCoreServer]({ (core, context) =>
+      // `--disableCatchingExceptions` lets the InterruptedException caused by interrupting the
+      // verification propagate (instead of Silicon reporting it as a verification failure), such
+      // that the interrupted verification ends without an overall verdict. This mirrors how e.g.
+      // Gobra invokes Silicon:
+      val siliconConfig = SiliconConfig(List("--disableCaching", "--disableCatchingExceptions"))
+      val jid = core.verify(long_running_file, siliconConfig, getAstByFileName(long_running_file))
+      assert(jid.id >= 0)
+      val messagesFuture = ViperCoreServerUtils.getMessagesFuture(core, jid)(context)
+      // give the verification some time to reach the backend:
+      Thread.sleep(2000)
+      // the path explosion keeps Silicon busy practically forever, i.e. the verification can
+      // only end via the interrupt below:
+      assert(!messagesFuture.isCompleted,
+        "the supposedly long-running verification finished before it could be interrupted")
+      // bound the wait for the message stream so that a regression hangs this test case for 60s
+      // instead of forever:
+      val boundedMessagesFuture = Future.firstCompletedOf(Seq(
+        messagesFuture,
+        akka.pattern.after(60 seconds, context.actorSystem.scheduler)(
+          Future.failed(new java.util.concurrent.TimeoutException(
+            "the interrupted verification's message stream did not complete")))(context)
+      ))(context)
+      core.interruptVerification(jid).flatMap(interrupted => {
+        // assert before waiting on the stream such that a failed interrupt is reported as the
+        // root cause instead of as a timed-out stream:
+        assert(interrupted)
+        // the stream completes only once the interrupted verification's task has finished its
+        // teardown and completed its queue. Note that this observes the task's cleanup having
+        // run, not directly that the backend's prover processes are gone (destroying them is the
+        // backend's responsibility within that teardown):
+        boundedMessagesFuture.flatMap(messages => {
+          // an interrupted verification must not report an overall verdict:
+          assert(!messages.exists(_.isInstanceOf[OverallSuccessMessage]))
+          assert(!messages.exists(_.isInstanceOf[OverallFailureMessage]))
+          // the interrupted job's slot must have been freed. This is only falsifiable when
+          // submitting the maximum number of concurrently active jobs: if the interrupted job's
+          // slot leaked, one of the following submissions would be rejected with a negative id:
+          val jids = (1 to core.config.maximumActiveJobs()).map(_ =>
+            verifySiliconWithoutCaching(core, correct_viper_file))
+          assert(jids.forall(_.id >= 0))
+          val resultFutures = jids.map(jid2 => ViperCoreServerUtils.getResultsFuture(core, jid2)(context))
+          resultFutures.foldLeft(Future.successful(succeed))((accFuture, resultFuture) =>
+            accFuture.flatMap(_ =>
+              resultFuture.map(result => assert(result === VerifierSuccess))(context))(context))
+        })(context)
+      })(context)
+    })
+
+    s"return false when interrupting an unknown verification job" in withServer[ViperCoreServer]({ (core, context) =>
+      core.interruptVerification(VerJobId(12345)).map(interrupted => assert(!interrupted))(context)
     })
 
     s"be able to verify a single program with caching enabled" in withServer[ViperCoreServer]({ (core, context) =>

--- a/src/test/scala/viper/server/vsi/TaskInterruptionTests.scala
+++ b/src/test/scala/viper/server/vsi/TaskInterruptionTests.scala
@@ -21,7 +21,8 @@ import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 
-/** a minimal [[MessageStreamingTask]] recording whether its callable ever ran */
+/** a minimal `MessageStreamingTask` recording whether its callable ever ran.
+  */
 class ProbeTask extends MessageStreamingTask[Unit] {
   type A = String
   override def pack(m: String): Envelope = ProbeEnvelope(m)

--- a/src/test/scala/viper/server/vsi/TaskInterruptionTests.scala
+++ b/src/test/scala/viper/server/vsi/TaskInterruptionTests.scala
@@ -1,0 +1,139 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2026 ETH Zurich.
+
+package viper.server.vsi
+
+import akka.actor.ActorSystem
+import akka.pattern.ask
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.util.Timeout
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import viper.server.core.{DefaultVerificationExecutionContext, VerificationExecutionContext}
+
+import java.util.concurrent.{CountDownLatch, ExecutorService, TimeUnit, Future => JFuture}
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.language.postfixOps
+import scala.util.control.NonFatal
+
+/** a minimal [[MessageStreamingTask]] recording whether its callable ever ran */
+class ProbeTask extends MessageStreamingTask[Unit] {
+  type A = String
+  override def pack(m: String): Envelope = ProbeEnvelope(m)
+  override def unpack(e: Envelope): String = e.asInstanceOf[ProbeEnvelope].s
+
+  @volatile var ran: Boolean = false
+  /** released once the callable has started; used by tests that cancel a running task */
+  val startedLatch = new CountDownLatch(1)
+  /** the callable blocks on this latch until it is interrupted or released */
+  val blockLatch = new CountDownLatch(1)
+  /** whether the callable should block on `blockLatch` after starting */
+  @volatile var blockUntilInterrupted: Boolean = false
+
+  override def call(): Unit = {
+    ran = true
+    startedLatch.countDown()
+    if (blockUntilInterrupted) {
+      blockLatch.await()
+    }
+  }
+}
+case class ProbeEnvelope(s: String) extends Envelope
+
+class TaskInterruptionTests extends AnyWordSpec with Matchers {
+
+  "MessageStreamingTask" should {
+
+    "report cancelledBeforeStart for a task that is cancelled before it executes" in {
+      val task = new ProbeTask
+      assert(!task.cancelledBeforeStart)
+      task.futureTask.cancel(true)
+      assert(task.cancelledBeforeStart)
+      // executing the cancelled task must not run its callable:
+      task.futureTask.run()
+      assert(!task.ran)
+      // the answer is stable:
+      assert(task.cancelledBeforeStart)
+    }
+
+    "not report cancelledBeforeStart for a completed task" in {
+      val task = new ProbeTask
+      task.futureTask.run()
+      assert(task.ran)
+      task.futureTask.cancel(true) // has no effect on a completed task
+      assert(!task.cancelledBeforeStart)
+    }
+
+    "not report cancelledBeforeStart for a task that is cancelled while it is running" in {
+      val task = new ProbeTask
+      task.blockUntilInterrupted = true
+      val thread = new Thread(task.futureTask)
+      thread.start()
+      assert(task.startedLatch.await(5, TimeUnit.SECONDS))
+      task.futureTask.cancel(true)
+      assert(!task.cancelledBeforeStart)
+      task.blockLatch.countDown() // in case the interrupt was not observed
+      thread.join(5000)
+      assert(!thread.isAlive)
+      assert(task.ran)
+      assert(!task.cancelledBeforeStart)
+    }
+  }
+
+  "JobActor" should {
+
+    "complete the message queue when stopping a task that never started" in {
+      val context = new DefaultVerificationExecutionContext(actorSystemName = "TaskInterruptionTests")
+      try {
+        implicit val system: ActorSystem = context.actorSystem
+        implicit val askTimeout: Timeout = Timeout(5 seconds)
+
+        /** delegates to `context` but drops submitted tasks, simulating a saturated thread pool
+          * whose queued task is stopped before any thread ever picks it up */
+        val droppingExecutor: VerificationExecutionContext = new VerificationExecutionContext {
+          override def execute(runnable: Runnable): Unit = { /* drop */ }
+          override def reportFailure(cause: Throwable): Unit = context.reportFailure(cause)
+          override def executorService: ExecutorService = context.executorService
+          override def actorSystem: ActorSystem = context.actorSystem
+          override def submit(r: Runnable): JFuture[_] = context.submit(r)
+          override def terminate(timeoutMSec: Long): Unit = ()
+          override def restart(): Future[Unit] = Future.successful(())
+        }
+
+        val (queue, publisher) = Source.queue[Envelope](10, OverflowStrategy.backpressure)
+          .toMat(Sink.asPublisher(false))(Keep.both).run()
+        val task = new ProbeTask
+        // mirror `initializeProcess`, which attaches a QueueActor to every task -- the JobActor
+        // completes the queue of a never-started task through this actor:
+        task.setQueueActor(system.actorOf(QueueActor.props(queue)))
+        val jobActor = system.actorOf(JobActor.props[Unit](VerJobId(0)))
+
+        val handle = Await.result(
+          (jobActor ? VerificationProtocol.Verify[Unit](task, queue, publisher, None, droppingExecutor)).mapTo[VerHandle],
+          5 seconds)
+        assert(handle.job_actor == jobActor)
+
+        val reply = Await.result((jobActor ? VerificationProtocol.StopVerification).mapTo[String], 5 seconds)
+        assert(JobActor.indicatesInterrupted(reply))
+
+        // without the JobActor completing the queue on behalf of the never-started task, this
+        // would hang forever (nobody else ever completes the queue):
+        Await.result(queue.watchCompletion(), 5 seconds)
+        assert(task.cancelledBeforeStart)
+        assert(!task.ran)
+      } finally {
+        // never let termination problems mask the actual test outcome:
+        try {
+          context.terminate(10000)
+        } catch {
+          case NonFatal(e) => println(s"terminating the execution context failed: $e")
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/viper/server/vsi/TaskInterruptionTests.scala
+++ b/src/test/scala/viper/server/vsi/TaskInterruptionTests.scala
@@ -118,8 +118,10 @@ class TaskInterruptionTests extends AnyWordSpec with Matchers {
           5 seconds)
         assert(handle.job_actor == jobActor)
 
-        val reply = Await.result((jobActor ? VerificationProtocol.StopVerification).mapTo[String], 5 seconds)
-        assert(JobActor.indicatesInterrupted(reply))
+        val reply = Await.result(
+          (jobActor ? VerificationProtocol.StopVerification).mapTo[VerificationProtocol.StopProcessReply],
+          5 seconds)
+        assert(reply.interrupted)
 
         // without the JobActor completing the queue on behalf of the never-started task, this
         // would hang forever (nobody else ever completes the queue):


### PR DESCRIPTION
This PR adds `interruptVerification` and `interruptAstConstruction` such that clients have a publicly exposed API to interrupt submitted (and potentially running) jobs. In addition, this PR addresses two hangs / leaks that could have occurred when interrupting jobs (cf. individual commit messages)