### PR TITLE
Auto-merge submodule updates by squashing

### DIFF
--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -70,10 +70,6 @@ jobs:
             ${{ env.PR_BODY_LINE1 }}
             ${{ env.PR_BODY_LINE2 }}
 
-      # Note that this requires "Allow auto-merge" to be enabled in this repository's settings
-      # (Settings > General > Pull Requests). Squashing is used because it is the only merge
-      # method that this repository permits; when the base branch is governed by a merge queue,
-      # the queue's merge method takes precedence over this flag.
       - name: Enable auto-merge of PR
         if: (env.PREV_SILICON_REF != env.CUR_SILICON_REF) || (env.PREV_CARBON_REF != env.CUR_CARBON_REF)
         run: gh pr merge --squash --auto "${{ steps.pr.outputs.pull-request-number }}"

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -70,8 +70,12 @@ jobs:
             ${{ env.PR_BODY_LINE1 }}
             ${{ env.PR_BODY_LINE2 }}
 
+      # Note that this requires "Allow auto-merge" to be enabled in this repository's settings
+      # (Settings > General > Pull Requests). Squashing is used because it is the only merge
+      # method that this repository permits; when the base branch is governed by a merge queue,
+      # the queue's merge method takes precedence over this flag.
       - name: Enable auto-merge of PR
         if: (env.PREV_SILICON_REF != env.CUR_SILICON_REF) || (env.PREV_CARBON_REF != env.CUR_CARBON_REF)
-        run: gh pr merge --merge --auto "${{ steps.pr.outputs.pull-request-number }}"
+        run: gh pr merge --squash --auto "${{ steps.pr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ secrets.VIPER_ADMIN_TOKEN }}


### PR DESCRIPTION
The daily *Update Submodules* workflow has failed on every run since 2026-07-08 (46 consecutive failures; last success 2026-07-07). It still opens its PR successfully, but the subsequent *Enable auto-merge of PR* step fails, so the submodule updates pile up unmerged — #354 is green and `MERGEABLE`, just never merged.

The failing step reports two independent problems:

```
! The merge strategy for master is set by the merge queue
GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)
```

Note that the workflow itself has not been touched since February 2026, i.e. this repository's merge settings evidently changed underneath it.

## What this PR changes

`gh pr merge --merge --auto` requests a merge commit, which this repository no longer permits (`allow_merge_commit: false`). This PR requests a squash instead, the only merge method that is enabled here. Should the base branch be governed by a merge queue, the queue's merge method takes precedence over that flag anyway, so this works in either configuration.

## What this PR cannot change: the repository settings

The second error is a repository setting and hence out of this PR's reach: **"Allow auto-merge" is disabled for this repository**, which makes `gh pr merge --auto` fail regardless of the merge method. A repository admin has to enable it, either via

*Settings* → *General* → *Pull Requests* → :white_check_mark: *Allow auto-merge*

or via

```bash
gh api -X PATCH repos/viperproject/viperserver -F allow_auto_merge=true
```

**Both changes are required** — this PR alone does not fix the workflow.

For reference, every sibling repository already has that setting enabled:

| repository | `allow_auto_merge` | `allow_merge_commit` | `allow_squash_merge` |
| --- | :---: | :---: | :---: |
| gobra-ide | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| gobra | :white_check_mark: | :x: | :white_check_mark: |
| silicon | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| **viperserver** | :x: | :x: | :white_check_mark: |

Gobra-IDE's workflow is otherwise identical to this one and has been merging its submodule updates without a single failure, which is the behavior this PR restores here.

## Follow-up (not part of this PR)

Gobra's workflow has its *Enable auto-merge of PR* step commented out and `allow_merge_commit: false` as well, i.e. it would hit the same merge-method problem. The same one-line change would revive it there.